### PR TITLE
Parallel save

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /root/
 
 RUN pip install numpy
 RUN pip install pylint mypy pytest types-setuptools
-RUN pip install h3==4.0.0b2
+RUN pip install h3==4.0.0b5
 
 RUN python3 -m pytest -vv
 # RUN mypy yirgacheffe

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ There are two ways to store the result of a computation. In all the above exampl
 ```python
 
 def print_progress(p)
-    print(f"We have made {p *100} percent progress")
+    print(f"We have made {p * 100} percent progress")
 
 ...
 
@@ -306,6 +306,23 @@ total_area = calc.sum()
 ```
 
 Similar to sum, you can also call `min` and `max` on a layer or calculation.
+
+## Experimental
+
+There is a parallel version of save, that is added as an experimental feature for testing in our wider codebase, which
+will run concurrently the save over many threads.
+
+```
+calc.parallel_save(result)
+```
+
+By default it will use as many CPU cores as are available, but if you want to limit that you can pass an extra argument to constrain that:
+
+```
+calc.parallel_save(result, parallelism=4)
+```
+
+Because of the number of tricks that Python plays under the hood this feature needs a bunch of testing to let us remove the experimental flag, but in order to get that testing we need to put it out there! Hopefully in the next release we can remove the experimental warning.
 
 
 ## Thanks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "0.7.0"
+version = "0.7.1"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "0.7.2"
+version = "0.7.3"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "0.7.1"
+version = "0.7.2"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]
-keywords = ["gdal", "numpy", "math"]
+keywords = ["gdal", "numpy", "math", "pathos"]
 dependencies = [
     "numpy",
     "gdal",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]
-keywords = ["gdal", "numpy", "math", "pathos"]
+keywords = ["gdal", "numpy", "math"]
 dependencies = [
     "numpy",
     "gdal",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "0.6.33"
+version = "0.7.0"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -65,13 +65,18 @@ def gdal_dataset_of_layer(layer: YirgacheffeLayer, filename: Optional[str]=None)
     dataset.SetProjection(layer.projection)
     return dataset
 
-def gdal_dataset_with_data(origin: Tuple, pixel_pitch: float, data: np.array) -> gdal.Dataset:
+def gdal_dataset_with_data(origin: Tuple, pixel_pitch: float, data: np.array, filename: Optional[str]=None) -> gdal.Dataset:
     assert data.ndim == 2
     datatype = gdal.GDT_Byte
     if isinstance(data[0][0], float):
         datatype = gdal.GDT_Float64
-    dataset = gdal.GetDriverByName('mem').Create(
-        'mem',
+    if filename:
+        driver = gdal.GetDriverByName('GTiff')
+    else:
+        driver = gdal.GetDriverByName('mem')
+        filename = 'mem'
+    dataset = driver.Create(
+        filename,
         len(data[0]),
         len(data),
         1,

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pytest
 
-from helpers import gdal_dataset_with_data
+from helpers import gdal_dataset_with_data, gdal_dataset_of_region
 from yirgacheffe.layers import RasterLayer, ConstantLayer
 from yirgacheffe.operators import LayerOperation
+from yirgacheffe.window import Area
 
 def test_add_byte_layers() -> None:
     data1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])

--- a/tests/test_parallel_operators.py
+++ b/tests/test_parallel_operators.py
@@ -55,14 +55,18 @@ def test_parallel_with_different_skip(skip, expected_steps) -> None:
         layer2 = RasterLayer.layer_from_file(path2)
         result = RasterLayer.empty_raster_layer_like(layer1)
 
+        callback_possitions = []
+
         comp = layer1 + layer2
         comp.ystep = skip
-        comp.parallel_save(result)
+        comp.parallel_save(result, callback=lambda x: callback_possitions.append(x))
 
         expected = data1 + data2
         actual = result.read_array(0, 0, 4, 2)
 
         assert (expected == actual).all()
+
+        assert callback_possitions == expected_steps
 
 def test_parallel_unary_numpy_apply_with_function() -> None:
     with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_parallel_operators.py
+++ b/tests/test_parallel_operators.py
@@ -30,9 +30,6 @@ def test_add_byte_layers() -> None:
         expected = data1 + data2
         actual = result.read_array(0, 0, 4, 2)
 
-        print(f"expected: {expected}")
-        print(f"actual: {actual}")
-
         assert (expected == actual).all()
 
 @pytest.mark.parametrize("skip,expected_steps", [

--- a/tests/test_parallel_operators.py
+++ b/tests/test_parallel_operators.py
@@ -63,3 +63,43 @@ def test_parallel_with_different_skip(skip, expected_steps) -> None:
         actual = result.read_array(0, 0, 4, 2)
 
         assert (expected == actual).all()
+
+def test_parallel_unary_numpy_apply_with_function() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        path1 = os.path.join(tempdir, "test1.tif")
+        data1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        dataset1 = gdal_dataset_with_data((0.0, 0.0), 0.02, data1, filename=path1)
+        dataset1.Close()
+        layer1 = RasterLayer.layer_from_file(path1)
+
+        result = RasterLayer.empty_raster_layer_like(layer1)
+
+        def simple_add(chunk):
+            return chunk + 1.0
+
+        comp = layer1.numpy_apply(simple_add)
+        comp.parallel_save(result)
+
+        expected = data1 + 1.0
+        actual = result.read_array(0, 0, 4, 2)
+
+        assert (expected == actual).all()
+
+
+def test_parallel_unary_numpy_apply_with_lambda() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        path1 = os.path.join(tempdir, "test1.tif")
+        data1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        dataset1 = gdal_dataset_with_data((0.0, 0.0), 0.02, data1, filename=path1)
+        dataset1.Close()
+        layer1 = RasterLayer.layer_from_file(path1)
+
+        result = RasterLayer.empty_raster_layer_like(layer1)
+
+        comp = layer1.numpy_apply(lambda a: a + 1.0)
+        comp.parallel_save(result)
+
+        expected = data1 + 1.0
+        actual = result.read_array(0, 0, 4, 2)
+
+        assert (expected == actual).all()

--- a/tests/test_parallel_operators.py
+++ b/tests/test_parallel_operators.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from helpers import gdal_dataset_with_data
+from yirgacheffe.layers import RasterLayer, ConstantLayer
+from yirgacheffe.operators import LayerOperation
+
+def test_add_byte_layers() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        path1 = os.path.join(tempdir, "test1.tif")
+        data1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        dataset1 = gdal_dataset_with_data((0.0, 0.0), 0.02, data1, filename=path1)
+        dataset1.Close()
+
+        path2 = os.path.join(tempdir, "test2.tif")
+        data2 = np.array([[10, 20, 30, 40], [50, 60, 70, 80]])
+        dataset2 = gdal_dataset_with_data((0.0, 0.0), 0.02, data2, filename=path2)
+        dataset2.Close()
+
+        layer1 = RasterLayer.layer_from_file(path1)
+        layer2 = RasterLayer.layer_from_file(path2)
+        result = RasterLayer.empty_raster_layer_like(layer1)
+
+        comp = layer1 + layer2
+        comp.parallel_save(result)
+
+        expected = data1 + data2
+        actual = result.read_array(0, 0, 4, 2)
+
+        print(f"expected: {expected}")
+        print(f"actual: {actual}")
+
+        assert (expected == actual).all()
+
+@pytest.mark.parametrize("skip,expected_steps", [
+    (1, [0.0, 0.5, 1.0]),
+    (2, [0.0, 1.0]),
+])
+def test_parallel_with_different_skip(skip, expected_steps) -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        path1 = os.path.join(tempdir, "test1.tif")
+        data1 = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        dataset1 = gdal_dataset_with_data((0.0, 0.0), 0.02, data1, filename=path1)
+        dataset1.Close()
+
+        path2 = os.path.join(tempdir, "test2.tif")
+        data2 = np.array([[10, 20, 30, 40], [50, 60, 70, 80]])
+        dataset2 = gdal_dataset_with_data((0.0, 0.0), 0.02, data2, filename=path2)
+        dataset2.Close()
+
+        layer1 = RasterLayer.layer_from_file(path1)
+        layer2 = RasterLayer.layer_from_file(path2)
+        result = RasterLayer.empty_raster_layer_like(layer1)
+
+        comp = layer1 + layer2
+        comp.ystep = skip
+        comp.parallel_save(result)
+
+        expected = data1 + data2
+        actual = result.read_array(0, 0, 4, 2)
+
+        assert (expected == actual).all()

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,50 @@
+import os
+import pickle
+import tempfile
+
+import pytest
+
+from helpers import gdal_dataset_of_region, make_vectors_with_id
+from yirgacheffe.window import Area, PixelScale, Window
+from yirgacheffe.layers import RasterLayer, VectorLayer
+from yirgacheffe import WGS_84_PROJECTION
+
+
+def test_pickle_raster_layer() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        path = os.path.join(tempdir, "test.tif")
+        area = Area(-10, 10, 10, -10)
+        layer = RasterLayer(gdal_dataset_of_region(area, 0.02, filename=path))
+
+        p = pickle.dumps(layer)
+        restore = pickle.loads(p)
+
+        assert restore.area == area
+        assert restore.pixel_scale == (0.02, -0.02)
+        assert restore.geo_transform == (-10, 0.02, 0.0, 10, 0.0, -0.02)
+        assert restore.window == Window(0, 0, 1000, 1000)
+
+def test_pickle_raster_mem_layer_fails() -> None:
+    area = Area(-10, 10, 10, -10)
+    layer = RasterLayer(gdal_dataset_of_region(area, 0.02))
+
+    with pytest.raises(ValueError):
+        _ = pickle.dumps(layer)
+
+def test_pickle_dyanamic_vector_layer() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        path = os.path.join(tempdir, "test.gpkg")
+        area = Area(-10.0, 10.0, 10.0, 0.0)
+        make_vectors_with_id(42, {area}, path)
+
+        layer = VectorLayer.layer_from_file(path, "id_no = 42", PixelScale(1.0, -1.0), WGS_84_PROJECTION)
+
+        p = pickle.dumps(layer)
+        restore = pickle.loads(p)
+
+        assert restore.area == area
+        assert restore.geo_transform == (area.left, 1.0, 0.0, area.top, 0.0, -1.0)
+        assert restore.window == Window(0, 0, 20, 10)
+        assert restore.projection == WGS_84_PROJECTION
+
+        del layer

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,12 +1,15 @@
+
+import math
 import os
 import pickle
 import tempfile
 
+import numpy as np
 import pytest
 
 from helpers import gdal_dataset_of_region, make_vectors_with_id
 from yirgacheffe.window import Area, PixelScale, Window
-from yirgacheffe.layers import RasterLayer, VectorLayer
+from yirgacheffe.layers import GroupLayer, RasterLayer, UniformAreaLayer, VectorLayer
 from yirgacheffe import WGS_84_PROJECTION
 
 
@@ -48,3 +51,59 @@ def test_pickle_dyanamic_vector_layer() -> None:
         assert restore.projection == WGS_84_PROJECTION
 
         del layer
+
+def test_pickle_uniform_area_layer() -> None:
+    pixel_scale = 0.2
+    with tempfile.TemporaryDirectory() as tempdir:
+        path = os.path.join(tempdir, "test.tif")
+        area = Area(
+            math.floor(-180 / pixel_scale) * pixel_scale, 
+            math.ceil(90 / pixel_scale) * pixel_scale, 
+            (math.floor(-180 / pixel_scale) * pixel_scale) + pixel_scale, 
+            math.floor(-90 / pixel_scale) * pixel_scale
+        )
+        dataset = gdal_dataset_of_region(area, pixel_scale, filename=path)
+        assert dataset.RasterXSize == 1
+        assert dataset.RasterYSize == math.ceil(180 / pixel_scale)
+        dataset.Close()
+        del dataset
+
+        layer = UniformAreaLayer.layer_from_file(path)
+
+        p = pickle.dumps(layer)
+        restore = pickle.loads(p)
+
+        assert restore.pixel_scale == (pixel_scale, -pixel_scale)
+        assert restore.area == Area(
+            math.floor(-180 / pixel_scale) * pixel_scale, 
+            math.ceil(90 / pixel_scale) * pixel_scale, 
+            math.ceil(180 / pixel_scale) * pixel_scale, 
+            math.floor(-90 / pixel_scale) * pixel_scale
+        )
+        assert restore.window == Window(
+            0,
+            0,
+            math.ceil((restore.area.right - restore.area.left) / pixel_scale), 
+            math.ceil((restore.area.top - restore.area.bottom) / pixel_scale)
+        )
+
+def test_pickle_group_layer():
+    with tempfile.TemporaryDirectory() as tempdir:
+        path = os.path.join(tempdir, "test.tif")
+        area = Area(-10, 10, 10, -10)
+        dataset = gdal_dataset_of_region(area, 0.2, filename=path)
+        dataset.Close()
+        del dataset
+
+        group = GroupLayer.layer_from_directory(tempdir)
+        expected = group.read_array(0, 0, 100, 100)
+        assert np.sum(expected) != 0 # just check there is meaninful data
+
+        p = pickle.dumps(group)
+        restore = pickle.loads(p)
+
+        assert restore.area == area
+        assert restore.window == Window(0, 0, 100, 100)
+
+        result = restore.read_array(0, 0, 100, 100)
+        assert (expected == result).all()

--- a/yirgacheffe/__init__.py
+++ b/yirgacheffe/__init__.py
@@ -4,6 +4,9 @@ try:
 except DistributionNotFound:
     pass  # package is not installed
 
+from osgeo import gdal
+gdal.UseExceptions()
+
 # I don't really want this here, but it's just too useful having it exposed
 WGS_84_PROJECTION = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,'\
     'AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],'\

--- a/yirgacheffe/__init__.py
+++ b/yirgacheffe/__init__.py
@@ -1,10 +1,10 @@
+from osgeo import gdal
 from pkg_resources import get_distribution, DistributionNotFound
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     pass  # package is not installed
 
-from osgeo import gdal
 gdal.UseExceptions()
 
 # I don't really want this here, but it's just too useful having it exposed

--- a/yirgacheffe/layers/group.py
+++ b/yirgacheffe/layers/group.py
@@ -63,6 +63,13 @@ class GroupLayer(YirgacheffeLayer):
         self._underlying_layers.reverse()
         self.layers = self._underlying_layers
 
+    def _park(self):
+        for layer in self.layers:
+            try:
+                layer._park()
+            except AttributeError:
+                pass
+
     def set_window_for_intersection(self, new_area: Area) -> None:
         super().set_window_for_intersection(new_area)
 

--- a/yirgacheffe/layers/rasters.py
+++ b/yirgacheffe/layers/rasters.py
@@ -32,7 +32,8 @@ class RasterLayer(YirgacheffeLayer):
         name: Optional[str]=None,
         compress: bool=True,
         nodata: Optional[Union[float,int]]=None,
-        nbits: Optional[int]=None
+        nbits: Optional[int]=None,
+        threads: Optional[int]=None
     ) -> RasterLayerT:
         abs_xstep, abs_ystep = abs(scale.xstep), abs(scale.ystep)
 
@@ -45,6 +46,8 @@ class RasterLayer(YirgacheffeLayer):
         )
 
         options = []
+        if threads is not None:
+            options.append(f"NUM_THREADS={threads}")
         if nbits is not None:
             options.append(f"NBITS={nbits}")
 
@@ -53,6 +56,8 @@ class RasterLayer(YirgacheffeLayer):
             options.append('BIGTIFF=YES')
             if compress:
                 options.append('COMPRESS=LZW')
+            else:
+                options.append('COMPRESS=NONE')
         else:
             driver = gdal.GetDriverByName('mem')
             filename = 'mem'
@@ -81,7 +86,8 @@ class RasterLayer(YirgacheffeLayer):
         datatype: Optional[int]=None,
         compress: bool=True,
         nodata: Optional[Union[float,int]]=None,
-        nbits: Optional[int]=None
+        nbits: Optional[int]=None,
+        threads: Optional[int]=None
     ) -> RasterLayerT:
         width = layer.window.xsize
         height = layer.window.ysize
@@ -98,6 +104,8 @@ class RasterLayer(YirgacheffeLayer):
             )
 
         options = []
+        if threads is not None:
+            options.append(f"NUM_THREADS={threads}")
         if nbits is not None:
             options.append(f"NBITS={nbits}")
 
@@ -106,6 +114,8 @@ class RasterLayer(YirgacheffeLayer):
             options.append('BIGTIFF=YES')
             if compress:
                 options.append('COMPRESS=LZW')
+            else:
+                options.append('COMPRESS=NONE')
         else:
             driver = gdal.GetDriverByName('mem')
             filename = 'mem'

--- a/yirgacheffe/layers/rasters.py
+++ b/yirgacheffe/layers/rasters.py
@@ -229,6 +229,7 @@ class RasterLayer(YirgacheffeLayer):
         if not os.path.isfile(self._dataset_path):
             raise ValueError("Can not pickle layer that is not file backed.")
         odict = self.__dict__.copy()
+        self._park()
         del odict['_dataset']
         return odict
 
@@ -237,6 +238,10 @@ class RasterLayer(YirgacheffeLayer):
         self._unpark()
 
     def _park(self):
+        try:
+            self._dataset.Close()
+        except AttributeError:
+            pass
         self._dataset = None
 
     def _unpark(self):

--- a/yirgacheffe/layers/vectors.py
+++ b/yirgacheffe/layers/vectors.py
@@ -254,6 +254,7 @@ class VectorLayer(YirgacheffeLayer):
         self.burn_value = burn_value
 
         self._original = None
+        self._filter = None
 
         # work out region for mask
         envelopes = []

--- a/yirgacheffe/operators.py
+++ b/yirgacheffe/operators.py
@@ -1,12 +1,12 @@
 import sys
 import time
-from multiprocessing import Semaphore, Process
 import multiprocessing
+from multiprocessing import Semaphore, Process
+from multiprocessing.managers import SharedMemoryManager
 
 import numpy as np
 from osgeo import gdal
 
-from multiprocessing.managers import SharedMemoryManager
 
 from .window import Window
 
@@ -279,7 +279,7 @@ class LayerOperation(LayerMathMixin):
 
                 mem_and_locks = [
                     (
-                        smm.SharedMemory(size=(np_dtype.itemsize * self.ystep * destination_window.xsize)),
+                        smm.SharedMemory(size=np_dtype.itemsize * self.ystep * destination_window.xsize),
                         Semaphore(),
                     ) for _ in range(worker_count)
                 ]

--- a/yirgacheffe/operators.py
+++ b/yirgacheffe/operators.py
@@ -1,9 +1,11 @@
-import multiprocessing
 from functools import partial
 
 import numpy as np
+import pathos.multiprocessing as multiprocessing
 
 from .window import Window
+
+
 
 YSTEP = 512
 


### PR DESCRIPTION
This adds a new experimental feature, which is parallel save. Compared to regular save, which breaks work into chunks to prevent memory overloading, parallel save will throw those chunks out to different CPU cores. In practices this doesn't give you as big a win as you might expect, due to collating and saving the work is still a serialised operation, and with large GeoTIFFs with LZW compression that becomes the bottleneck. 