### PR TITLE
Remove deprecated pkg_resources call

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "numpy<2" gdal[numpy] scikit-image "h3==4.0.0b5"
+          python -m pip install "numpy<2" gdal[numpy]==3.9.2 scikit-image "h3==4.0.0b5"
           python -m pip install pylint mypy pytest types-setuptools
       - name: Lint with pylint
         run: |

--- a/yirgacheffe/__init__.py
+++ b/yirgacheffe/__init__.py
@@ -1,9 +1,9 @@
 from osgeo import gdal
-from pkg_resources import get_distribution, DistributionNotFound
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    pass  # package is not installed
+    from importlib import metadata
+    __version__ = metadata.version(__name__)
+except ModuleNotFoundError:
+    __version__ = "unknown"
 
 gdal.UseExceptions()
 


### PR DESCRIPTION
The old code failed to handle the module not found exception, and used a now deprecated call to get the version.