### PR TITLE
Add more numpy like operators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "0.8.7"
+version = "0.8.8"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "0.8.8"
+version = "0.9.0"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -170,7 +170,7 @@ def make_vectors_with_id(identifier: int, areas: Set[Area], filename: str) -> No
     feature.SetField("id_no", identifier)
     layer.CreateFeature(feature)
 
-    package.Destroy()
+    package.Close()
 
 def make_vectors_with_mutlile_ids(areas: Set[Tuple[Area,int]], filename: str) -> None:
     srs = ogr.osr.SpatialReference()
@@ -203,7 +203,7 @@ def make_vectors_with_mutlile_ids(areas: Set[Tuple[Area,int]], filename: str) ->
         feature.SetField("id_no", identifier)
         layer.CreateFeature(feature)
 
-    package.Destroy()
+    package.Close()
 
 def generate_child_tile(xoffset: int, yoffset: int, width: int, height: int, outer_width: int, outer_height: int) -> np.ndarray:
     data = np.zeros((height, width))
@@ -248,4 +248,4 @@ def make_vectors_with_empty_feature(areas: Set[Tuple[Area,int]], filename: str) 
     feature = ogr.Feature(feature_definition)
     layer.CreateFeature(feature)
 
-    package.Destroy()
+    package.Close()

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -648,3 +648,29 @@ def test_or_int_layers() -> None:
     actual = result.read_array(0, 0, 4, 2)
 
     assert (expected == actual).all()
+
+def test_nan_to_num() -> None:
+    data1 = np.array([[float('nan'), float('nan'), float('nan'), float('nan')], [1, 2, 3, 0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = layer1.nan_to_num(nan=42)
+    comp.save(result)
+
+    expected = np.array([[42, 42, 42, 42], [1, 2, 3, 0]])
+    actual = result.read_array(0, 0, 4, 2)
+
+    assert (expected == actual).all()
+
+def test_nan_to_num_default() -> None:
+    data1 = np.array([[float('nan'), float('nan'), float('nan'), float('nan')], [1, 2, 3, 0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = layer1.nan_to_num()
+    comp.save(result)
+
+    expected = np.array([[0, 0, 0, 0], [1, 2, 3, 0]])
+    actual = result.read_array(0, 0, 4, 2)
+
+    assert (expected == actual).all()

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -706,4 +706,16 @@ def test_where_layers() -> None:
     expected = np.where(data1 > 0, data_a, data_b)
     actual = result.read_array(0, 0, 4, 2)
     assert (expected == actual).all()
-    
+
+def test_isin_simple() -> None:
+    data1 = np.array([[0, 1, 0, 2], [0, 0, 1, 1]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = layer1.isin([2, 3])
+    comp.ystep = 1
+    comp.save(result)
+
+    expected = np.isin(data1, [2, 3])
+    actual = result.read_array(0, 0, 4, 2)
+    assert (expected == actual).all()

--- a/tests/test_parallel_operators.py
+++ b/tests/test_parallel_operators.py
@@ -79,13 +79,13 @@ def test_parallel_unary_numpy_apply_with_function() -> None:
             return chunk + 1.0
 
         comp = layer1.numpy_apply(simple_add)
+        comp.ystep = 1
         comp.parallel_save(result)
 
         expected = data1 + 1.0
         actual = result.read_array(0, 0, 4, 2)
 
         assert (expected == actual).all()
-
 
 def test_parallel_unary_numpy_apply_with_lambda() -> None:
     with tempfile.TemporaryDirectory() as tempdir:
@@ -98,9 +98,28 @@ def test_parallel_unary_numpy_apply_with_lambda() -> None:
         result = RasterLayer.empty_raster_layer_like(layer1)
 
         comp = layer1.numpy_apply(lambda a: a + 1.0)
+        comp.ystep = 1
         comp.parallel_save(result)
 
         expected = data1 + 1.0
         actual = result.read_array(0, 0, 4, 2)
 
+        assert (expected == actual).all()
+
+def test_parallel_where_simple() -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        path1 = os.path.join(tempdir, "test1.tif")
+        data1 = np.array([[0, 1, 0, 2], [0, 0, 1, 1]])
+        dataset1 = gdal_dataset_with_data((0.0, 0.0), 0.02, data1, filename=path1)
+        dataset1.Close()
+        layer1 = RasterLayer.layer_from_file(path1)
+        
+        result = RasterLayer.empty_raster_layer_like(layer1)
+    
+        comp = LayerOperation.where(layer1 > 0, 1, 2)
+        comp.ystep = 1
+        comp.parallel_save(result)
+    
+        expected = np.where(data1 > 0, 1, 2)
+        actual = result.read_array(0, 0, 4, 2)
         assert (expected == actual).all()

--- a/yirgacheffe/operators.py
+++ b/yirgacheffe/operators.py
@@ -72,6 +72,13 @@ class LayerMathMixin:
         except AttributeError:
             return self.read_array(0, index, target_window.xsize if target_window else 1, step)
 
+    def nan_to_num(self, nan=0, posinf=None, neginf=None):
+        return LayerOperation(
+            self,
+            lambda c: np.nan_to_num(c, copy=False, nan=nan, posinf=posinf, neginf=neginf),
+            None,
+        )
+
     def numpy_apply(self, func, other=None):
         return LayerOperation(self, func, other)
 

--- a/yirgacheffe/operators.py
+++ b/yirgacheffe/operators.py
@@ -79,6 +79,13 @@ class LayerMathMixin:
             None,
         )
 
+    def isin(self, vals):
+        return LayerOperation(
+            self,
+            lambda c: np.isin(c, vals),
+            None,
+        )
+
     def numpy_apply(self, func, other=None):
         return LayerOperation(self, func, other)
 


### PR DESCRIPTION
In an attempt to reduce the need for folk to use numpy_apply, I've added some more numpy style operators.

This will also make it easier to then add back in the cupy backend, as that won't work if you are explicitly using numpy functions this way.