### PR TITLE
Fully virtual vector layers

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install gdal[numpy]==3.11.0 scikit-image torch "h3==4.0.0b5" mlx[cpu]
-          python -m pip install pylint mypy pytest types-setuptools pytest-cov build twine
+          python -m pip install pylint mypy pytest types-setuptools pytest-cov build twine deprecation
 
       - name: Lint with pylint
         run: python3 -m pylint .

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install gdal[numpy]==3.11.0 scikit-image torch "h3==4.0.0b5" mlx[cpu]
-          python -m pip install pylint mypy pytest types-setuptools pytest-cov build twine deprecation
+          python -m pip install pylint mypy pytest types-setuptools pytest-cov build twine deprecation tomli
 
       - name: Lint with pylint
         run: python3 -m pylint .

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install gdal[numpy]==3.11.0 scikit-image torch "h3==4.0.0b5" mlx[cpu]
-          python -m pip install pylint mypy pytest types-setuptools pytest-cov build twine deprecation
+          python -m pip install pylint mypy pytest types-setuptools pytest-cov build twine deprecation tomli
 
       - name: Lint with pylint
         run: python3 -m pylint .

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install gdal[numpy]==3.11.0 scikit-image torch "h3==4.0.0b5" mlx[cpu]
-          python -m pip install pylint mypy pytest types-setuptools pytest-cov build twine
+          python -m pip install pylint mypy pytest types-setuptools pytest-cov build twine deprecation
 
       - name: Lint with pylint
         run: python3 -m pylint .

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import yirgaceffe as yg
 
 habitat_map = yg.read_raster("habitats.tif")
 elevation_map = yg.read_raster('elevation.tif')
-range_polygon = yg.read_shape_like('species123.geojson', like=habitat_map)
+range_polygon = yg.read_shape('species123.geojson')
 area_per_pixel_map = yg.read_raster('area_per_pixel.tif')
 
 refined_habitat = habitat_map.isin([...species habitat codes...])
@@ -152,22 +152,22 @@ with VectorLayer.layer_from_file('range.gpkg', PixelScale(0.001, -0.001), WGS_84
     ...
 ```
 
-The new 2.0 way of doing this is:
+The new 2.0 way of doing this is, if you plan to use the vector layer in calculation with other raster layers that will have projection information:
 
 ```python
 import yirgacheffe as yg
 
-with yg.read_shape('range.gpkg', (0.001, -0.001), WGS_84_PROJECTION) as layer:
+with yg.read_shape('range.gpkg') as layer:
     ...
 ```
 
-It is more common that when a shape file is loaded that its pixel size and projection will want to be made to match that of an existing raster (as per the opening area of habitat example). For that there is the following convenience method:
-
+Of if you plan to use the layer on its own and want to specify a rasterisation projection you can do:
 
 ```python
-with yg.read_raster("test.tif") as raster_layer:
-    with yg.read_shape_like('range.gpkg', raster_layer) as shape_layer:
-        ...
+import yirgacheffe as yg
+
+with yg.read_shape('range.gpkg', (yg.WGS_84_PROJECTION, (0.001, -0.001))) as layer:
+    ...
 ```
 
 ### GroupLayer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "torch",
     "dill",
     "deprecation",
+    "tomli"
 ]
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "1.6.1"
+version = "1.7.0"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]
@@ -18,6 +18,7 @@ dependencies = [
     "scikit-image",
     "torch",
     "dill",
+    "deprecation",
 ]
 requires-python = ">=3.10"
 
@@ -36,4 +37,8 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "h3.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "deprecation.*"
 ignore_missing_imports = true

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,13 +5,12 @@ import pytest
 
 from yirgacheffe import WGS_84_PROJECTION
 from yirgacheffe.layers import YirgacheffeLayer
-from yirgacheffe.window import Area, PixelScale
+from yirgacheffe.window import Area, MapProjection
 
 def test_pixel_to_latlng_unsupported_projection() -> None:
     layer = YirgacheffeLayer(
         Area(-10, 10, 10, -10),
-        PixelScale(0.02, -0.02),
-        "OTHER PROJECTION"
+        MapProjection("OTHER PROJECTION", 0.02, -0.02),
     )
     with pytest.raises(NotImplementedError):
         _ = layer.latlng_for_pixel(10, 10)
@@ -19,8 +18,7 @@ def test_pixel_to_latlng_unsupported_projection() -> None:
 def test_pixel_from_latlng_unsupported_projection() -> None:
     layer = YirgacheffeLayer(
         Area(-10, 10, 10, -10),
-        PixelScale(0.02, -0.02),
-        "OTHER PROJECTION"
+        MapProjection("OTHER PROJECTION", 0.02, -0.02),
     )
     with pytest.raises(NotImplementedError):
         _ = layer.pixel_for_latlng(10.0, 10.0)
@@ -63,8 +61,7 @@ def test_pixel_from_latlng_unsupported_projection() -> None:
 def test_latlng_for_pixel(area: Area, pixel: Tuple[int,int], expected: Tuple[float,float]) -> None:
     layer = YirgacheffeLayer(
         area,
-        PixelScale(0.2, -0.2),
-        WGS_84_PROJECTION
+        MapProjection(WGS_84_PROJECTION, 0.2, -0.2),
     )
     result = layer.latlng_for_pixel(*pixel)
     assert math.isclose(result[0], expected[0])
@@ -93,8 +90,7 @@ def test_latlng_for_pixel(area: Area, pixel: Tuple[int,int], expected: Tuple[flo
 def test_pixel_for_latlng(area: Area, coord: Tuple[float,float], expected: Tuple[int,int]) -> None:
     layer = YirgacheffeLayer(
         area,
-        PixelScale(0.2, -0.2),
-        WGS_84_PROJECTION
+        MapProjection(WGS_84_PROJECTION, 0.2, -0.2),
     )
     result = layer.pixel_for_latlng(*coord)
     assert result == expected
@@ -149,8 +145,7 @@ def test_latlng_for_pixel_with_intersection(
 ) -> None:
     layer = YirgacheffeLayer(
         area,
-        PixelScale(0.2, -0.2),
-        WGS_84_PROJECTION
+        MapProjection(WGS_84_PROJECTION, 0.2, -0.2),
     )
     layer.set_window_for_intersection(window)
     result = layer.latlng_for_pixel(*pixel)
@@ -188,8 +183,7 @@ def test_pixel_for_latlng_with_intersection(
 ) -> None:
     layer = YirgacheffeLayer(
         area,
-        PixelScale(0.2, -0.2),
-        WGS_84_PROJECTION
+        MapProjection(WGS_84_PROJECTION, 0.2, -0.2),
     )
     layer.set_window_for_intersection(window)
     result = layer.pixel_for_latlng(*coord)

--- a/tests/test_h3layer.py
+++ b/tests/test_h3layer.py
@@ -5,7 +5,7 @@ from osgeo import gdal
 
 from yirgacheffe import WGS_84_PROJECTION
 from yirgacheffe.layers import RasterLayer, H3CellLayer
-from yirgacheffe.window import Area, PixelScale
+from yirgacheffe.window import Area, MapProjection
 from yirgacheffe._backends import backend
 
 # work around of pylint
@@ -21,7 +21,7 @@ demote_array = backend.demote_array
 )
 def test_h3_layer(cell_id: str, is_valid: bool, expected_zoom: int) -> None:
     if is_valid:
-        with H3CellLayer(cell_id, PixelScale(0.001, -0.001), WGS_84_PROJECTION) as layer:
+        with H3CellLayer(cell_id, MapProjection(WGS_84_PROJECTION, 0.001, -0.001)) as layer:
             assert layer.zoom == expected_zoom
             assert layer.projection == WGS_84_PROJECTION
 
@@ -35,7 +35,7 @@ def test_h3_layer(cell_id: str, is_valid: bool, expected_zoom: int) -> None:
             assert one_count != 0
     else:
         with pytest.raises(ValueError):
-            with H3CellLayer(cell_id, PixelScale(0.001, -0.001), WGS_84_PROJECTION) as _layer:
+            with H3CellLayer(cell_id, MapProjection(WGS_84_PROJECTION, 0.001, -0.001)) as _layer:
                 pass
 
 @pytest.mark.parametrize(
@@ -53,8 +53,10 @@ def test_h3_layer(cell_id: str, is_valid: bool, expected_zoom: int) -> None:
 def test_h3_layer_magnifications(lat: float, lng: float) -> None:
     for zoom in range(6, 10):
         cell_id = h3.latlng_to_cell(lat, lng, zoom)
-        h3_layer = H3CellLayer(cell_id, PixelScale(0.000898315284120,-0.000898315284120), WGS_84_PROJECTION)
-
+        h3_layer = H3CellLayer(
+            cell_id,
+            MapProjection(WGS_84_PROJECTION, 0.000898315284120,-0.000898315284120)
+        )
         on_cell_count = h3_layer.sum()
         total_count = h3_layer.window.xsize * h3_layer.window.ysize
         assert 0 < on_cell_count < total_count
@@ -74,14 +76,18 @@ def test_h3_layer_magnifications(lat: float, lng: float) -> None:
 def test_h3_layer_not_clipped(lat: float, lng: float) -> None:
     for zoom in range(6, 10):
         cell_id = h3.latlng_to_cell(lat, lng, zoom)
-        scale = PixelScale(0.000898315284120,-0.000898315284120)
-        h3_layer = H3CellLayer(cell_id, scale, WGS_84_PROJECTION)
+        projection = MapProjection(
+            WGS_84_PROJECTION,
+            0.000898315284120,
+            -0.000898315284120
+        )
+        h3_layer = H3CellLayer(cell_id, projection)
 
         on_cell_count = h3_layer.sum()
         assert on_cell_count > 0.0
 
         before_window = h3_layer.window
-        abs_xstep, abs_ystep = abs(scale.xstep), abs(scale.ystep)
+        abs_xstep, abs_ystep = abs(projection.xstep), abs(projection.ystep)
         expanded_area = Area(
             left=h3_layer.area.left - (12 * abs_xstep),
             top=h3_layer.area.top + (12 * abs_ystep),
@@ -115,14 +121,18 @@ def test_h3_layer_not_clipped(lat: float, lng: float) -> None:
 def test_h3_layer_clipped(lat: float, lng: float) -> None:
     for zoom in range(6, 8):
         cell_id = h3.latlng_to_cell(lat, lng, zoom)
-        scale = PixelScale(0.000898315284120,-0.000898315284120)
-        h3_layer = H3CellLayer(cell_id, scale, WGS_84_PROJECTION)
+        projection = MapProjection(
+            WGS_84_PROJECTION,
+            0.000898315284120,
+            -0.000898315284120
+        )
+        h3_layer = H3CellLayer(cell_id, projection)
 
         on_cell_count = h3_layer.sum()
         assert on_cell_count > 0.0
 
         before_window = h3_layer.window
-        abs_xstep, abs_ystep = abs(scale.xstep), abs(scale.ystep)
+        abs_xstep, abs_ystep = abs(projection.xstep), abs(projection.ystep)
         expanded_area = Area(
             left=h3_layer.area.left + (2 * abs_xstep),
             top=h3_layer.area.top - (2 * abs_ystep),
@@ -151,8 +161,8 @@ def test_h3_layer_clipped(lat: float, lng: float) -> None:
 )
 def test_h3_layer_wrapped_on_projection(lat: float, lng: float) -> None:
     cell_id = h3.latlng_to_cell(lat, lng, 3)
-    scale = PixelScale(0.01, -0.01)
-    h3_layer = H3CellLayer(cell_id, scale, WGS_84_PROJECTION)
+    projection = MapProjection(WGS_84_PROJECTION, 0.01, -0.01)
+    h3_layer = H3CellLayer(cell_id, projection)
 
     # Just sanity check this test has caught a cell that wraps the entire planet and is testing
     # what we think it is testing:
@@ -165,14 +175,14 @@ def test_h3_layer_wrapped_on_projection(lat: float, lng: float) -> None:
     # check they are all of a similarish size - we had a bug early on where we'd
     # mistakenly invert the area for the band, counting all the cells across the planet
     for cell_id in h3.grid_ring(cell_id, 1):
-        neighbour = H3CellLayer(cell_id, scale, WGS_84_PROJECTION)
+        neighbour = H3CellLayer(cell_id, projection)
         neighbour_area = neighbour.sum()
         # We're happy if they're within 10% for now
         assert abs((neighbour_area - area) / area) < 0.1
 
 
     before_window = h3_layer.window
-    _, abs_ystep = abs(scale.xstep), abs(scale.ystep)
+    _, abs_ystep = abs(projection.xstep), abs(projection.ystep)
     expanded_area = Area(
         left=h3_layer.area.left,
         top=h3_layer.area.top + (22 * abs_ystep),
@@ -198,7 +208,11 @@ def test_h3_layer_overlapped():
     # This is based on a regression, where somehow I made tiles not tesselate properly
     left, top = (121.26706, 19.45338)
     right, bottom = (121.62494, 19.18478)
-    scale = PixelScale(0.000898315284120,-0.000898315284120)
+    projection = MapProjection(
+        WGS_84_PROJECTION,
+        0.000898315284120,
+        -0.000898315284120
+    )
 
     cells = h3.geo_to_cells(h3.LatLngPoly([
         (top, left),
@@ -208,13 +222,13 @@ def test_h3_layer_overlapped():
     ],), 7)
 
     tiles = [
-        H3CellLayer(cell_id, scale, WGS_84_PROJECTION)
+        H3CellLayer(cell_id, projection)
     for cell_id in cells]
 
     union = RasterLayer.find_union(tiles)
     union = union.grow(0.02)
 
-    scratch = RasterLayer.empty_raster_layer(union, scale, gdal.GDT_Float64)
+    scratch = RasterLayer.empty_raster_layer(union, projection.scale, gdal.GDT_Float64)
 
     # In scratch we should only have 0 or 1 values, but if there are any overlaps we should get 2s...
 

--- a/tests/test_intersection.py
+++ b/tests/test_intersection.py
@@ -2,7 +2,7 @@ import pytest
 from osgeo import gdal
 
 from tests.helpers import gdal_dataset_of_region, gdal_empty_dataset_of_region
-from yirgacheffe.window import Area, PixelScale, Window
+from yirgacheffe.window import Area, MapProjection, Window
 from yirgacheffe.layers import RasterLayer, ConstantLayer, H3CellLayer
 from yirgacheffe import WGS_84_PROJECTION
 
@@ -149,10 +149,10 @@ def test_intersection_stability():
     # a rounding error that causes set_window_for_* methods to wobble depending on how far
     # away from the top left thing where. adding round_down_pixels fixed this.
     cells = ["874b93aaeffffff", "874b93a85ffffff", "874b93aa3ffffff", "874b93a84ffffff", "874b93a80ffffff"]
-    scale = PixelScale(0.000898315284120,-0.000898315284120)
+    projection = MapProjection(WGS_84_PROJECTION, 0.000898315284120,-0.000898315284120)
 
     tiles = [
-        H3CellLayer(cell_id, scale, WGS_84_PROJECTION)
+        H3CellLayer(cell_id, projection)
     for cell_id in cells]
 
     # composing the same tiles within different areas should not cause them to
@@ -160,8 +160,8 @@ def test_intersection_stability():
     union = RasterLayer.find_union(tiles)
     superunion = union.grow(0.02)
 
-    scratch1 = RasterLayer.empty_raster_layer(union, scale, gdal.GDT_Float64, name='s1')
-    scratch2 = RasterLayer.empty_raster_layer(superunion, scale, gdal.GDT_Float64, name='s2')
+    scratch1 = RasterLayer.empty_raster_layer(union, projection.scale, gdal.GDT_Float64, name='s1')
+    scratch2 = RasterLayer.empty_raster_layer(superunion, projection.scale, gdal.GDT_Float64, name='s2')
 
     relative_offsets = {}
 

--- a/tests/test_multiband.py
+++ b/tests/test_multiband.py
@@ -16,7 +16,7 @@ def test_simple_two_band_image() -> None:
         bands = 4
         target = RasterLayer.empty_raster_layer(
             Area(-1, 1, 1, -1),
-            PixelScale(1.0, 1.0),
+            PixelScale(1.0, -1.0),
             gdal.GDT_Byte,
             filename=target_path,
             bands=bands

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 
 from yirgacheffe import WGS_84_PROJECTION
-from yirgacheffe.layers import PixelScale, RasterLayer, H3CellLayer
-from yirgacheffe.window import Area
+from yirgacheffe.layers import RasterLayer, H3CellLayer
+from yirgacheffe.window import Area, MapProjection
 import yirgacheffe.operators as yo
 
 class NaiveH3CellLayer(H3CellLayer):
@@ -14,13 +14,14 @@ class NaiveH3CellLayer(H3CellLayer):
     version that checks for every cell."""
 
     def read_array(self, xoffset, yoffset, xsize, ysize): # pylint: disable=W0237
+        assert self._projection is not None
         res = np.zeros((ysize, xsize), dtype=float)
-        start_x = self._active_area.left + (xoffset * self._pixel_scale.xstep)
-        start_y = self._active_area.top + (yoffset * self._pixel_scale.ystep)
+        start_x = self._active_area.left + (xoffset * self._projection.xstep)
+        start_y = self._active_area.top + (yoffset * self._projection.ystep)
         for ypixel in range(ysize):
-            lat = start_y + (ypixel * self._pixel_scale.ystep)
+            lat = start_y + (ypixel * self._projection.ystep)
             for xpixel in range(xsize):
-                lng = start_x + (xpixel * self._pixel_scale.xstep)
+                lng = start_x + (xpixel * self._projection.xstep)
                 this_cell = h3.latlng_to_cell(lat, lng, self.zoom)
                 if this_cell == self.cell_id:
                     res[ypixel][xpixel] = 1.0
@@ -41,8 +42,9 @@ class NaiveH3CellLayer(H3CellLayer):
 def test_h3_vs_naive(lat: float, lng: float) -> None:
     for zoom in range(5, 9):
         cell_id = h3.latlng_to_cell(lat, lng, zoom)
-        optimised_layer = H3CellLayer(cell_id, PixelScale(0.000898315284120,-0.000898315284120), "NOTUSED")
-        naive_layer = NaiveH3CellLayer(cell_id, PixelScale(0.000898315284120,-0.000898315284120), "NOTUSED")
+        projection = MapProjection(WGS_84_PROJECTION, 0.000898315284120,-0.000898315284120)
+        optimised_layer = H3CellLayer(cell_id, projection)
+        naive_layer = NaiveH3CellLayer(cell_id, projection)
 
         optimised_cell_count = optimised_layer.sum()
         naive_cell_count = naive_layer.sum()
@@ -65,17 +67,17 @@ def test_h3_vs_naive(lat: float, lng: float) -> None:
 def test_h3_vs_naive_for_union(lat: float, lng: float) -> None:
     for zoom in range(7, 9):
         cell_id = h3.latlng_to_cell(lat, lng, zoom)
-        scale = PixelScale(0.000898315284120,-0.000898315284120)
-        optimised_layer = H3CellLayer(cell_id, scale, "NOTUSED")
-        naive_layer = NaiveH3CellLayer(cell_id, scale, "NOTUSED")
+        projection = MapProjection(WGS_84_PROJECTION, 0.000898315284120,-0.000898315284120)
+        optimised_layer = H3CellLayer(cell_id, projection)
+        naive_layer = NaiveH3CellLayer(cell_id, projection)
 
         before_cell_count = optimised_layer.sum()
 
         superset_area = Area(
-            left=optimised_layer.area.left - (5 * scale.xstep),
-            right=optimised_layer.area.right + (5 * scale.xstep),
-            top=optimised_layer.area.top - (5 * scale.ystep),
-            bottom=optimised_layer.area.bottom + (5 * scale.ystep),
+            left=optimised_layer.area.left - (5 * projection.xstep),
+            right=optimised_layer.area.right + (5 * projection.xstep),
+            top=optimised_layer.area.top - (5 * projection.ystep),
+            bottom=optimised_layer.area.bottom + (5 * projection.ystep),
         )
         optimised_layer.set_window_for_union(superset_area)
         naive_layer.set_window_for_union(superset_area)
@@ -101,17 +103,17 @@ def test_h3_vs_naive_for_union(lat: float, lng: float) -> None:
 def test_h3_vs_naive_for_intersection(lat: float, lng: float) -> None:
     for zoom in range(7, 9):
         cell_id = h3.latlng_to_cell(lat, lng, zoom)
-        scale = PixelScale(0.000898315284120,-0.000898315284120)
-        optimised_layer = H3CellLayer(cell_id, scale, "NOTUSED")
-        naive_layer = NaiveH3CellLayer(cell_id, scale, "NOTUSED")
+        projection = MapProjection(WGS_84_PROJECTION, 0.000898315284120,-0.000898315284120)
+        optimised_layer = H3CellLayer(cell_id, projection)
+        naive_layer = NaiveH3CellLayer(cell_id, projection)
 
         before_cell_count = optimised_layer.sum()
 
         subset_area = Area(
-            left=optimised_layer.area.left + (2 * scale.xstep),
-            right=optimised_layer.area.right - (2 * scale.xstep),
-            top=optimised_layer.area.top + (2 * scale.ystep),
-            bottom=optimised_layer.area.bottom - (2 * scale.ystep),
+            left=optimised_layer.area.left + (2 * projection.xstep),
+            right=optimised_layer.area.right - (2 * projection.xstep),
+            top=optimised_layer.area.top + (2 * projection.ystep),
+            bottom=optimised_layer.area.bottom - (2 * projection.ystep),
         )
         optimised_layer.set_window_for_intersection(subset_area)
         naive_layer.set_window_for_intersection(subset_area)
@@ -143,8 +145,8 @@ def test_h3_vs_naive_for_intersection(lat: float, lng: float) -> None:
 def test_cells_dont_overlap(cell_id):
 
     cluster = h3.grid_disk(cell_id, 1)
-    scale = PixelScale(0.000898315284120,-0.000898315284120)
-    layers = [H3CellLayer(x, scale, WGS_84_PROJECTION) for x in cluster]
+    projection = MapProjection(WGS_84_PROJECTION, 0.000898315284120,-0.000898315284120)
+    layers = [H3CellLayer(x, projection) for x in cluster]
 
     union = RasterLayer.find_union(layers)
     for layer in layers:

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -16,8 +16,8 @@ class NaiveH3CellLayer(H3CellLayer):
     def read_array(self, xoffset, yoffset, xsize, ysize): # pylint: disable=W0237
         assert self._projection is not None
         res = np.zeros((ysize, xsize), dtype=float)
-        start_x = self._active_area.left + (xoffset * self._projection.xstep)
-        start_y = self._active_area.top + (yoffset * self._projection.ystep)
+        start_x = self.area.left + (xoffset * self._projection.xstep)
+        start_y = self.area.top + (yoffset * self._projection.ystep)
         for ypixel in range(ysize):
             lat = start_y + (ypixel * self._projection.ystep)
             for xpixel in range(xsize):

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from tests.helpers import gdal_dataset_of_region, make_vectors_with_id
-from yirgacheffe.window import Area, PixelScale, Window
+from yirgacheffe.window import Area, MapProjection, PixelScale, Window
 from yirgacheffe.layers import ConstantLayer, GroupLayer, RasterLayer, RescaledRasterLayer, \
     UniformAreaLayer, VectorLayer
 from yirgacheffe import WGS_84_PROJECTION
@@ -181,7 +181,7 @@ def test_pickle_rescaled_raster_layer() -> None:
         path = os.path.join(tempdir, "test.tif")
         area = Area(-10, 10, 10, -10)
         raster = RasterLayer(gdal_dataset_of_region(area, 0.02, filename=path))
-        layer = RescaledRasterLayer(raster, PixelScale(0.01, -0.01))
+        layer = RescaledRasterLayer(raster, MapProjection(WGS_84_PROJECTION, 0.01, -0.01))
 
         p = pickle.dumps(layer)
         restore = pickle.loads(p)

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,0 +1,32 @@
+import pytest
+
+from yirgacheffe.window import MapProjection
+from yirgacheffe.rounding import MINIMAL_DEGREE_OF_INTEREST
+
+def test_scale_from_projection() -> None:
+    projection = MapProjection("PROJ", 0.1, -0.1)
+    assert projection.name == "PROJ"
+    assert projection.xstep == 0.1
+    assert projection.ystep == -0.1
+
+    scale = projection.scale
+    assert scale.xstep == 0.1
+    assert scale.ystep == -0.1
+
+@pytest.mark.parametrize(
+    "lhs,rhs,is_equal",
+    [
+        (MapProjection("A", 0.1, -0.1), MapProjection("A", 0.1, -0.1), True),
+        (MapProjection("A", 0.1, -0.1), MapProjection("B", 0.1, -0.1), False),
+        (MapProjection("A", 0.1, -0.1), MapProjection("A", 0.1, 0.1), False),
+        (MapProjection("A", 0.1, -0.1), MapProjection("A", -0.1, 0.1), False),
+        (MapProjection("A", 0.1, -0.1), MapProjection("A", 0.1 + (MINIMAL_DEGREE_OF_INTEREST / 2), -0.1), True),
+        (MapProjection("A", 0.1, -0.1), MapProjection("A", 0.1 - (MINIMAL_DEGREE_OF_INTEREST / 2), -0.1), True),
+        (MapProjection("A", 0.1, -0.1), MapProjection("A", 0.1, -0.1 + (MINIMAL_DEGREE_OF_INTEREST / 2)), True),
+        (MapProjection("A", 0.1, -0.1), MapProjection("A", 0.1, -0.1 - (MINIMAL_DEGREE_OF_INTEREST / 2)), True),
+    ]
+)
+def test_projection_equality(lhs: MapProjection, rhs : MapProjection, is_equal: bool) -> None:
+    assert MINIMAL_DEGREE_OF_INTEREST > 0.0
+    assert (lhs == rhs) == is_equal
+    assert (lhs != rhs) == (not is_equal)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -147,7 +147,7 @@ def test_layer_with_positive_offset():
     assert source.window == Window(0, 0, 20 / 0.02, 20 / 0.02)
 
     source.offset_window_by_pixels(5)
-    assert source._active_area == Area(-10 - (5 * 0.02), 10 + (5 * 0.02), 10 + (5 * 0.02), -10 - (5 * 0.02))
+    assert source.area == Area(-10 - (5 * 0.02), 10 + (5 * 0.02), 10 + (5 * 0.02), -10 - (5 * 0.02))
     assert source.window == Window(-5, -5, int(20 / 0.02) + 10, int(20 / 0.02) + 10)
 
 def test_layer_with_zero_offset():
@@ -165,7 +165,7 @@ def test_layer_with_negative_offset():
     assert source.window == Window(0, 0, 20 / 0.02, 20 / 0.02)
 
     source.offset_window_by_pixels(-5)
-    assert source._active_area == Area(-10 + (5 * 0.02), 10 - (5 * 0.02), 10 - (5 * 0.02), -10 + (5 * 0.02))
+    assert source.area == Area(-10 + (5 * 0.02), 10 - (5 * 0.02), 10 - (5 * 0.02), -10 + (5 * 0.02))
     assert source.window == Window(5, 5, int(20 / 0.02) - 10, int(20 / 0.02) - 10)
 
 def test_layer_with_excessive_negative_offset():
@@ -181,7 +181,7 @@ def test_layer_offsets_accumulate():
     source.offset_window_by_pixels(5)
     source.offset_window_by_pixels(-5)
 
-    assert source._active_area == Area(-10, 10, 10, -10)
+    assert source.area == Area(-10, 10, 10, -10)
     assert source.window == Window(0, 0, 20 / 0.02, 20 / 0.02)
 
 def test_scale_up():

--- a/yirgacheffe/__init__.py
+++ b/yirgacheffe/__init__.py
@@ -1,7 +1,7 @@
 from osgeo import gdal
 try:
     from importlib import metadata
-    __version__ = metadata.version(__name__)
+    __version__: str = metadata.version(__name__)
 except ModuleNotFoundError:
     __version__ = "unknown"
 

--- a/yirgacheffe/__init__.py
+++ b/yirgacheffe/__init__.py
@@ -1,9 +1,16 @@
+from pathlib import Path
+
 from osgeo import gdal
+import tomli as tomllib
+
 try:
     from importlib import metadata
     __version__: str = metadata.version(__name__)
 except ModuleNotFoundError:
-    __version__ = "unknown"
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        pyproject_data = tomllib.load(f)
+    __version__ = pyproject_data["project"]["version"]
 
 from ._core import read_raster, read_rasters, read_shape, read_shape_like
 from .constants import WGS_84_PROJECTION

--- a/yirgacheffe/_core.py
+++ b/yirgacheffe/_core.py
@@ -5,7 +5,7 @@ from .layers.base import YirgacheffeLayer
 from .layers.group import GroupLayer, TiledGroupLayer
 from .layers.rasters import RasterLayer
 from .layers.vectors import VectorLayer
-from .window import PixelScale
+from .window import MapProjection
 from .operators import DataType
 
 def read_raster(
@@ -58,8 +58,7 @@ def read_rasters(
 
 def read_shape(
     filename: Union[Path,str],
-    scale: Union[PixelScale, Tuple[float,float]],
-    projection: str,
+    projection: Union[Optional[MapProjection],Optional[Tuple[str,Tuple[float,float]]]]=None,
     where_filter: Optional[str] = None,
     datatype: Optional[DataType] = None,
     burn_value: Union[int,float,str] = 1,
@@ -70,10 +69,8 @@ def read_shape(
     ----------
     filename : Path
         Path of raster file to open.
-    scale: PixelScale or tuple of float
-        The dimensions of each pixel.
-    projection: str
-        The map projection to use
+    projection: MapProjection or tuple, optional
+        The map projection to use,
     where_filter : str, optional
         For use with files with many entries (e.g., GPKG), applies this filter to the data.
     datatype: DataType, default=DataType.Byte
@@ -87,16 +84,17 @@ def read_shape(
         Returns an layer representing the vector data.
     """
 
-    if not isinstance(scale, PixelScale):
-        scale = PixelScale(scale[0], scale[1])
+    if projection is not None:
+        if not isinstance(projection, MapProjection):
+            projection_name, scale_tuple = projection
+            projection = MapProjection(projection_name, scale_tuple[0], scale_tuple[1])
 
-    return VectorLayer.layer_from_file(
+    return VectorLayer._future_layer_from_file(
         filename,
         where_filter,
-        scale,
         projection,
         datatype,
-        burn_value
+        burn_value,
     )
 
 def read_shape_like(

--- a/yirgacheffe/layers/area.py
+++ b/yirgacheffe/layers/area.py
@@ -65,13 +65,13 @@ class UniformAreaLayer(RasterLayer):
 
         transform = dataset.GetGeoTransform()
 
-        pixel_scale = self.pixel_scale
-        assert pixel_scale # from raster we should always have one
+        projection = self.map_projection
+        assert projection is not None # from raster we should always have one
 
         self._underlying_area = Area(
-            floor(-180 / pixel_scale.xstep) * pixel_scale.xstep,
+            floor(-180 / projection.xstep) * projection.xstep,
             self.area.top,
-            ceil(180 / pixel_scale.xstep) * pixel_scale.xstep,
+            ceil(180 / projection.xstep) * projection.xstep,
             self.area.bottom
         )
         self._active_area = self._underlying_area

--- a/yirgacheffe/layers/base.py
+++ b/yirgacheffe/layers/base.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Sequence, Tuple
 
 from ..operators import DataType, LayerMathMixin
 from ..rounding import almost_equal, are_pixel_scales_equal_enough, round_up_pixels, round_down_pixels
-from ..window import Area, PixelScale, Window
+from ..window import Area, MapProjection, PixelScale, Window
 
 class YirgacheffeLayer(LayerMathMixin):
     """The common base class for the different layer types. Most still inherit from RasterLayer as deep down
@@ -12,11 +12,13 @@ class YirgacheffeLayer(LayerMathMixin):
 
     def __init__(self,
         area: Area,
-        pixel_scale: Optional[PixelScale],
-        projection: str,
+        projection: Optional[MapProjection],
         name: Optional[str] = None
     ):
-        self._pixel_scale = pixel_scale
+        # This is just to catch code that uses the old private API
+        if projection is not None and not isinstance(projection, MapProjection):
+            raise TypeError("projection value of wrong type")
+
         self._underlying_area = area
         self._active_area = area
         self._projection = projection
@@ -49,12 +51,22 @@ class YirgacheffeLayer(LayerMathMixin):
         raise NotImplementedError("Must be overridden by subclass")
 
     @property
-    def projection(self) -> str:
-        return self._projection
+    def projection(self) -> Optional[str]:
+        if self._projection:
+            return self._projection.name
+        else:
+            return None
 
     @property
     def pixel_scale(self) -> Optional[PixelScale]:
-        return self._pixel_scale
+        if self._projection:
+            return PixelScale(self._projection.xstep, self._projection.ystep)
+        else:
+            return None
+
+    @property
+    def map_projection(self) -> Optional[MapProjection]:
+        return self._projection
 
     @property
     def area(self) -> Area:
@@ -109,11 +121,11 @@ class YirgacheffeLayer(LayerMathMixin):
 
     @property
     def geo_transform(self) -> Tuple[float, float, float, float, float, float]:
-        if self._pixel_scale is None:
+        if self._projection is None:
             raise ValueError("No geo transform for layers without explicit pixel scale")
         return (
-            self._active_area.left, self._pixel_scale.xstep, 0.0,
-            self._active_area.top, 0.0, self._pixel_scale.ystep
+            self._active_area.left, self._projection.xstep, 0.0,
+            self._active_area.top, 0.0, self._projection.ystep
         )
 
     def check_pixel_scale(self, scale: PixelScale) -> bool:
@@ -124,21 +136,21 @@ class YirgacheffeLayer(LayerMathMixin):
             almost_equal(our_scale.ystep, scale.ystep)
 
     def set_window_for_intersection(self, new_area: Area) -> None:
-        if self._pixel_scale is None:
+        if self._projection is None:
             raise ValueError("Can not set Window without explicit pixel scale")
 
         new_window = Window(
-            xoff=round_down_pixels((new_area.left - self._underlying_area.left) / self._pixel_scale.xstep,
-                self._pixel_scale.xstep),
-            yoff=round_down_pixels((self._underlying_area.top - new_area.top) / (self._pixel_scale.ystep * -1.0),
-                self._pixel_scale.ystep * -1.0),
+            xoff=round_down_pixels((new_area.left - self._underlying_area.left) / self._projection.xstep,
+                self._projection.xstep),
+            yoff=round_down_pixels((self._underlying_area.top - new_area.top) / (self._projection.ystep * -1.0),
+                self._projection.ystep * -1.0),
             xsize=round_up_pixels(
-                (new_area.right - new_area.left) / self._pixel_scale.xstep,
-                self._pixel_scale.xstep
+                (new_area.right - new_area.left) / self._projection.xstep,
+                self._projection.xstep
             ),
             ysize=round_up_pixels(
-                (new_area.top - new_area.bottom) / (self._pixel_scale.ystep * -1.0),
-                (self._pixel_scale.ystep * -1.0)
+                (new_area.top - new_area.bottom) / (self._projection.ystep * -1.0),
+                (self._projection.ystep * -1.0)
             ),
         )
         if (new_window.xoff < 0) or (new_window.yoff < 0):
@@ -156,21 +168,21 @@ class YirgacheffeLayer(LayerMathMixin):
         self._active_area = new_area
 
     def set_window_for_union(self, new_area: Area) -> None:
-        if self._pixel_scale is None:
+        if self._projection is None:
             raise ValueError("Can not set Window without explicit pixel scale")
 
         new_window = Window(
-            xoff=round_down_pixels((new_area.left - self._underlying_area.left) / self._pixel_scale.xstep,
-                self._pixel_scale.xstep),
-            yoff=round_down_pixels((self._underlying_area.top - new_area.top) / (self._pixel_scale.ystep * -1.0),
-                self._pixel_scale.ystep * -1.0),
+            xoff=round_down_pixels((new_area.left - self._underlying_area.left) / self._projection.xstep,
+                self._projection.xstep),
+            yoff=round_down_pixels((self._underlying_area.top - new_area.top) / (self._projection.ystep * -1.0),
+                self._projection.ystep * -1.0),
             xsize=round_up_pixels(
-                (new_area.right - new_area.left) / self._pixel_scale.xstep,
-                self._pixel_scale.xstep
+                (new_area.right - new_area.left) / self._projection.xstep,
+                self._projection.xstep
             ),
             ysize=round_up_pixels(
-                (new_area.top - new_area.bottom) / (self._pixel_scale.ystep * -1.0),
-                (self._pixel_scale.ystep * -1.0)
+                (new_area.top - new_area.bottom) / (self._projection.ystep * -1.0),
+                (self._projection.ystep * -1.0)
             ),
         )
         if (new_window.xoff > 0) or (new_window.yoff > 0):
@@ -189,13 +201,13 @@ class YirgacheffeLayer(LayerMathMixin):
 
     def reset_window(self) -> None:
         self._active_area = self._underlying_area
-        if self._pixel_scale:
-            abs_xstep, abs_ystep = abs(self._pixel_scale.xstep), abs(self._pixel_scale.ystep)
+        if self._projection:
+            abs_xstep, abs_ystep = abs(self._projection.xstep), abs(self._projection.ystep)
             self._window = Window(
                 xoff=0,
                 yoff=0,
-                xsize=round_up_pixels((self.area.right - self.area.left) / self._pixel_scale.xstep, abs_xstep),
-                ysize=round_up_pixels((self.area.bottom - self.area.top) / self._pixel_scale.ystep, abs_ystep),
+                xsize=round_up_pixels((self.area.right - self.area.left) / self._projection.xstep, abs_xstep),
+                ysize=round_up_pixels((self.area.bottom - self.area.top) / self._projection.ystep, abs_ystep),
             )
 
     def offset_window_by_pixels(self, offset: int) -> None:
@@ -249,20 +261,20 @@ class YirgacheffeLayer(LayerMathMixin):
         width: int,
         height: int,
     ) -> Any:
-        assert self._pixel_scale is not None
+        assert self._projection is not None
 
         target_window = Window(
-            xoff=round_down_pixels((target_area.left - self._underlying_area.left) / self._pixel_scale.xstep,
-                self._pixel_scale.xstep),
-            yoff=round_down_pixels((self._underlying_area.top - target_area.top) / (self._pixel_scale.ystep * -1.0),
-                self._pixel_scale.ystep * -1.0),
+            xoff=round_down_pixels((target_area.left - self._underlying_area.left) / self._projection.xstep,
+                self._projection.xstep),
+            yoff=round_down_pixels((self._underlying_area.top - target_area.top) / (self._projection.ystep * -1.0),
+                self._projection.ystep * -1.0),
             xsize=round_up_pixels(
-                (target_area.right - target_area.left) / self._pixel_scale.xstep,
-                self._pixel_scale.xstep
+                (target_area.right - target_area.left) / self._projection.xstep,
+                self._projection.xstep
             ),
             ysize=round_up_pixels(
-                (target_area.top - target_area.bottom) / (self._pixel_scale.ystep * -1.0),
-                (self._pixel_scale.ystep * -1.0)
+                (target_area.top - target_area.bottom) / (self._projection.ystep * -1.0),
+                (self._projection.ystep * -1.0)
             ),
         )
         return self._read_array_with_window(x, y, width, height, target_window)
@@ -290,25 +302,19 @@ class YirgacheffeLayer(LayerMathMixin):
 
     def latlng_for_pixel(self, x_coord: int, y_coord: int) -> Tuple[float,float]:
         """Get geo coords for pixel. This is relative to the set view window."""
-        if "WGS 84" not in self.projection:
+        if self._projection is None or "WGS 84" not in self._projection.name:
             raise NotImplementedError("Not yet supported for other projections")
-        pixel_scale = self.pixel_scale
-        if pixel_scale is None:
-            raise ValueError("Layer has no pixel scale")
         return (
-            (y_coord * pixel_scale.ystep) + self.area.top,
-            (x_coord * pixel_scale.xstep) + self.area.left
+            (y_coord * self._projection.ystep) + self.area.top,
+            (x_coord * self._projection.xstep) + self.area.left
         )
 
     def pixel_for_latlng(self, lat: float, lng: float) -> Tuple[int,int]:
         """Get pixel for geo coords. This is relative to the set view window.
         Result is rounded down to nearest pixel."""
-        if "WGS 84" not in self.projection:
+        if self._projection is None or "WGS 84" not in self._projection.name:
             raise NotImplementedError("Not yet supported for other projections")
-        pixel_scale = self.pixel_scale
-        if pixel_scale is None:
-            raise ValueError("Layer has no pixel scale")
         return (
-            round_down_pixels((lng - self.area.left) / pixel_scale.xstep, abs(pixel_scale.xstep)),
-            round_down_pixels((lat - self.area.top) / pixel_scale.ystep, abs(pixel_scale.ystep)),
+            round_down_pixels((lng - self.area.left) / self._projection.xstep, abs(self._projection.xstep)),
+            round_down_pixels((lat - self.area.top) / self._projection.ystep, abs(self._projection.ystep)),
         )

--- a/yirgacheffe/layers/base.py
+++ b/yirgacheffe/layers/base.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 from typing import Any, Optional, Sequence, Tuple
 
+import deprecation
+
+from .. import __version__
 from ..operators import DataType, LayerMathMixin
-from ..rounding import almost_equal, are_pixel_scales_equal_enough, round_up_pixels, round_down_pixels
+from ..rounding import almost_equal, round_up_pixels, round_down_pixels
 from ..window import Area, MapProjection, PixelScale, Window
 
 class YirgacheffeLayer(LayerMathMixin):
@@ -51,6 +54,12 @@ class YirgacheffeLayer(LayerMathMixin):
         raise NotImplementedError("Must be overridden by subclass")
 
     @property
+    @deprecation.deprecated(
+        deprecated_in="1.7",
+        removed_in="2.0",
+        current_version=__version__,
+        details="Use `map_projection` instead."
+    )
     def projection(self) -> Optional[str]:
         if self._projection:
             return self._projection.name
@@ -58,6 +67,12 @@ class YirgacheffeLayer(LayerMathMixin):
             return None
 
     @property
+    @deprecation.deprecated(
+        deprecated_in="1.7",
+        removed_in="2.0",
+        current_version=__version__,
+        details="Use `map_projection` instead."
+    )
     def pixel_scale(self) -> Optional[PixelScale]:
         if self._projection:
             return PixelScale(self._projection.xstep, self._projection.ystep)
@@ -89,8 +104,11 @@ class YirgacheffeLayer(LayerMathMixin):
 
         # This only makes sense (currently) if all layers
         # have the same pixel pitch (modulo desired accuracy)
-        if not are_pixel_scales_equal_enough([x.pixel_scale for x in layers]):
-            raise ValueError("Not all layers are at the same pixel scale")
+        projections = [x.map_projection for x in layers if x.map_projection is not None]
+        if not projections:
+            raise ValueError("No layers have a projection")
+        if not all(projections[0] == x for x in projections[1:]):
+            raise ValueError("Not all layers are at the same projectin or pixel scale")
 
         intersection = Area(
             left=max(x._underlying_area.left for x in layers),
@@ -109,8 +127,11 @@ class YirgacheffeLayer(LayerMathMixin):
 
         # This only makes sense (currently) if all layers
         # have the same pixel pitch (modulo desired accuracy)
-        if not are_pixel_scales_equal_enough([x.pixel_scale for x in layers]):
-            raise ValueError("Not all layers are at the same pixel scale")
+        projections = [x.map_projection for x in layers if x.map_projection is not None]
+        if not projections:
+            raise ValueError("No layers have a projection")
+        if not all(projections[0] == x for x in projections[1:]):
+            raise ValueError("Not all layers are at the same projectin or pixel scale")
 
         return Area(
             left=min(x._underlying_area.left for x in layers),

--- a/yirgacheffe/layers/base.py
+++ b/yirgacheffe/layers/base.py
@@ -151,7 +151,7 @@ class YirgacheffeLayer(LayerMathMixin):
     @property
     def geo_transform(self) -> Tuple[float, float, float, float, float, float]:
         if self._projection is None:
-            raise ValueError("No geo transform for layers without explicit pixel scale")
+            raise AttributeError("No geo transform for layers without explicit pixel scale")
         return (
             self.area.left, self._projection.xstep, 0.0,
             self.area.top, 0.0, self._projection.ystep

--- a/yirgacheffe/layers/constant.py
+++ b/yirgacheffe/layers/constant.py
@@ -4,7 +4,6 @@ from ..operators import DataType
 from ..window import Area, PixelScale, Window
 from .base import YirgacheffeLayer
 from .._backends import backend
-from ..constants import WGS_84_PROJECTION
 
 
 class ConstantLayer(YirgacheffeLayer):
@@ -12,7 +11,7 @@ class ConstantLayer(YirgacheffeLayer):
     missing (e.g., area) without having the calculation full of branches."""
     def __init__(self, value: Union[int,float]): # pylint: disable=W0231
         area = Area.world()
-        super().__init__(area, None, WGS_84_PROJECTION)
+        super().__init__(area, None)
         self.value = float(value)
 
     @property

--- a/yirgacheffe/layers/constant.py
+++ b/yirgacheffe/layers/constant.py
@@ -1,7 +1,7 @@
 from typing import Any, Union
 
 from ..operators import DataType
-from ..window import Area, PixelScale, Window
+from ..window import Area, MapProjection, PixelScale, Window
 from .base import YirgacheffeLayer
 from .._backends import backend
 
@@ -40,6 +40,7 @@ class ConstantLayer(YirgacheffeLayer):
     def _read_array_for_area(
         self,
         _target_area: Area,
+        _target_projection: MapProjection,
         x: int,
         y: int,
         width: int,

--- a/yirgacheffe/layers/group.py
+++ b/yirgacheffe/layers/group.py
@@ -59,7 +59,7 @@ class GroupLayer(YirgacheffeLayer):
         if not all(x.map_projection == layers[0].map_projection for x in layers):
             raise ValueError("Not all layers are the same projection/scale")
         for layer in layers:
-            if layer._active_area != layer._underlying_area:
+            if layer._active_area is not None:
                 raise ValueError("Layers can not currently be constrained")
 
         # area/window are superset of all tiles

--- a/yirgacheffe/layers/group.py
+++ b/yirgacheffe/layers/group.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy import ma
 
 from ..operators import DataType
-from ..rounding import are_pixel_scales_equal_enough, round_down_pixels
+from ..rounding import round_down_pixels
 from ..window import Area, Window
 from .base import YirgacheffeLayer
 from .rasters import RasterLayer
@@ -56,10 +56,8 @@ class GroupLayer(YirgacheffeLayer):
     ) -> None:
         if not layers:
             raise GroupLayerEmpty("Expected one or more layers")
-        if not are_pixel_scales_equal_enough([x.pixel_scale for x in layers]):
-            raise ValueError("Not all layers are at the same pixel scale")
         if not all(x.map_projection == layers[0].map_projection for x in layers):
-            raise ValueError("Not all layers are the same projection")
+            raise ValueError("Not all layers are the same projection/scale")
         for layer in layers:
             if layer._active_area != layer._underlying_area:
                 raise ValueError("Layers can not currently be constrained")

--- a/yirgacheffe/layers/group.py
+++ b/yirgacheffe/layers/group.py
@@ -58,7 +58,7 @@ class GroupLayer(YirgacheffeLayer):
             raise GroupLayerEmpty("Expected one or more layers")
         if not are_pixel_scales_equal_enough([x.pixel_scale for x in layers]):
             raise ValueError("Not all layers are at the same pixel scale")
-        if not all(x.projection == layers[0].projection for x in layers):
+        if not all(x.map_projection == layers[0].map_projection for x in layers):
             raise ValueError("Not all layers are the same projection")
         for layer in layers:
             if layer._active_area != layer._underlying_area:
@@ -66,7 +66,7 @@ class GroupLayer(YirgacheffeLayer):
 
         # area/window are superset of all tiles
         union = YirgacheffeLayer.find_union(layers)
-        super().__init__(union, layers[0].pixel_scale, layers[0].projection, name=name)
+        super().__init__(union, layers[0].map_projection, name=name)
 
         # We store them in reverse order so that from the user's perspective
         # the first layer in the list will be the most important in terms

--- a/yirgacheffe/layers/h3layer.py
+++ b/yirgacheffe/layers/h3layer.py
@@ -119,8 +119,8 @@ class H3CellLayer(YirgacheffeLayer):
 
             subset = np.zeros((intersection.ysize, intersection.xsize))
 
-            start_x = self._active_area.left + ((intersection.xoff - self.window.xoff) * self._projection.xstep)
-            start_y = self._active_area.top + ((intersection.yoff - self.window.yoff) * self._projection.ystep)
+            start_x = self.area.left + ((intersection.xoff - self.window.xoff) * self._projection.xstep)
+            start_y = self.area.top + ((intersection.yoff - self.window.yoff) * self._projection.ystep)
 
             for ypixel in range(intersection.ysize):
                 # The latlng_to_cell is quite expensive, so ideally we want to avoid
@@ -199,16 +199,16 @@ class H3CellLayer(YirgacheffeLayer):
             max_width = ceil(max_width_projection / self._projection.xstep)
 
             for ypixel in range(yoffset, yoffset + ysize):
-                lat = self._active_area.top + (ypixel * self._projection.ystep)
+                lat = self.area.top + (ypixel * self._projection.ystep)
 
                 for xpixel in range(xoffset, min(xoffset + xsize, max_width)):
-                    lng = self._active_area.left + (xpixel * self._projection.xstep)
+                    lng = self.area.left + (xpixel * self._projection.xstep)
                     this_cell = h3.latlng_to_cell(lat, lng, self.zoom)
                     if this_cell == self.cell_id:
                         res[ypixel - yoffset][xpixel - xoffset] = 1.0
 
                 for xpixel in range(xoffset + xsize - 1, xoffset + xsize - max_width, -1):
-                    lng = self._active_area.left + (xpixel * self._projection.xstep)
+                    lng = self.area.left + (xpixel * self._projection.xstep)
                     this_cell = h3.latlng_to_cell(lat, lng, self.zoom)
                     if this_cell == self.cell_id:
                         res[ypixel - yoffset][xpixel - xoffset] = 1.0

--- a/yirgacheffe/layers/rasters.py
+++ b/yirgacheffe/layers/rasters.py
@@ -7,7 +7,7 @@ import numpy as np
 from osgeo import gdal
 
 from ..constants import WGS_84_PROJECTION
-from ..window import Area, PixelScale, Window
+from ..window import Area, MapProjection, PixelScale, Window
 from ..rounding import round_up_pixels
 from .base import YirgacheffeLayer
 from ..operators import DataType
@@ -242,18 +242,17 @@ class RasterLayer(YirgacheffeLayer):
             raise ValueError("None is not a valid dataset")
 
         transform = dataset.GetGeoTransform()
-        scale = PixelScale(transform[1], transform[5])
+        projection = MapProjection(dataset.GetProjection(), transform[1], transform[5])
         area = Area(
             left=transform[0],
             top=transform[3],
-            right=transform[0] + (dataset.RasterXSize * scale.xstep),
-            bottom=transform[3] + (dataset.RasterYSize * scale.ystep),
+            right=transform[0] + (dataset.RasterXSize * projection.xstep),
+            bottom=transform[3] + (dataset.RasterYSize * projection.ystep),
         )
 
         super().__init__(
             area,
-            scale,
-            dataset.GetProjection(),
+            projection,
             name=name
         )
 

--- a/yirgacheffe/operators.py
+++ b/yirgacheffe/operators.py
@@ -442,9 +442,13 @@ class LayerOperation(LayerMathMixin):
     @property
     def projection(self):
         try:
-            return self.lhs.projection
+            projection = self.lhs.projection
         except AttributeError:
-            return self.rhs.projection
+            projection = None
+
+        if projection is None:
+            projection = self.rhs.projection
+        return projection
 
     def _eval(self, area: Area, index: int, step: int, target_window:Optional[Window]=None):
 

--- a/yirgacheffe/operators.py
+++ b/yirgacheffe/operators.py
@@ -20,7 +20,7 @@ from dill import dumps, loads # type: ignore
 
 from . import constants, __version__
 from .rounding import round_up_pixels, round_down_pixels
-from .window import Area, PixelScale, Window
+from .window import Area, PixelScale, MapProjection, Window
 from ._backends import backend
 from ._backends.enumeration import operators as op
 from ._backends.enumeration import dtype as DataType
@@ -39,14 +39,17 @@ class LayerConstant:
     def __init__(self, val):
         self.val = val
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.val)
 
-    def _eval(self, _area, _index, _step, _target_window):
+    def _eval(self, _area, _projection, _index, _step, _target_window):
         return self.val
 
     @property
-    def area(self):
+    def area(self) -> Area:
+        return Area.world()
+
+    def _get_operation_area(self, _projection) -> Area:
         return Area.world()
 
 class LayerMathMixin:
@@ -96,12 +99,26 @@ class LayerMathMixin:
     def __or__(self, other):
         return LayerOperation(self, op.OR, other, window_op=WindowOperation.UNION)
 
-    def _eval(self, area, index, step, target_window=None):
+    def _eval(
+        self,
+        area,
+        projection,
+        index,
+        step,
+        target_window=None
+    ):
         try:
             window = self.window if target_window is None else target_window
-            return self._read_array_for_area(area, 0, index, window.xsize, step)
+            return self._read_array_for_area(area, projection, 0, index, window.xsize, step)
         except AttributeError:
-            return self._read_array_for_area(area, 0, index, target_window.xsize if target_window else 1, step)
+            return self._read_array_for_area(
+                area,
+                projection,
+                0,
+                index,
+                target_window.xsize if target_window else 1,
+                step
+            )
 
     def nan_to_num(self, nan=0, posinf=None, neginf=None):
         return LayerOperation(
@@ -404,6 +421,49 @@ class LayerOperation(LayerMathMixin):
             case _:
                 assert False, "Should not be reached"
 
+    def _get_operation_area(self, projection: Optional[MapProjection]) -> Area:
+
+        # The type().__name__ here is to avoid a circular import dependancy
+        lhs_area = self.lhs._get_operation_area(projection)
+        try:
+            rhs_area = self.rhs._get_operation_area(projection)
+        except AttributeError:
+            rhs_area = None
+        try:
+            other_area = self.other._get_operation_area(projection)
+        except AttributeError:
+            other_area = None
+
+        all_areas = [x for x in [lhs_area, rhs_area, other_area] if (x is not None) and (not x.is_world)]
+
+        match self.window_op:
+            case WindowOperation.NONE:
+                return all_areas[0]
+            case WindowOperation.LEFT:
+                return lhs_area
+            case WindowOperation.RIGHT:
+                assert rhs_area is not None
+                return rhs_area
+            case WindowOperation.INTERSECTION:
+                intersection = Area(
+                    left=max(x.left for x in all_areas),
+                    top=min(x.top for x in all_areas),
+                    right=min(x.right for x in all_areas),
+                    bottom=max(x.bottom for x in all_areas)
+                )
+                if (intersection.left >= intersection.right) or (intersection.bottom >= intersection.top):
+                    raise ValueError('No intersection possible')
+                return intersection
+            case WindowOperation.UNION:
+                return Area(
+                    left=min(x.left for x in all_areas),
+                    top=max(x.top for x in all_areas),
+                    right=max(x.right for x in all_areas),
+                    bottom=min(x.bottom for x in all_areas)
+                )
+            case _:
+                assert False, "Should not be reached"
+
     @property
     @deprecation.deprecated(
         deprecated_in="1.7",
@@ -426,7 +486,10 @@ class LayerOperation(LayerMathMixin):
     @property
     def window(self) -> Window:
         projection = self.map_projection
-        area = self.area
+        if projection is None:
+            # This can happen if your source layers are say just constants
+            raise AttributeError("No window without projection")
+        area = self._get_operation_area(projection)
         assert area is not None
 
         return Window(
@@ -464,27 +527,36 @@ class LayerOperation(LayerMathMixin):
         return projection
 
     @property
-    def map_projection(self):
+    def map_projection(self) -> Optional[MapProjection]:
         try:
             projection = self.lhs.map_projection
         except AttributeError:
             projection = None
 
         if projection is None:
-            projection = self.rhs.map_projection
+            try:
+                projection = self.rhs.map_projection
+            except AttributeError:
+                pass
         return projection
 
-    def _eval(self, area: Area, index: int, step: int, target_window:Optional[Window]=None):
+    def _eval(
+        self,
+        area: Area,
+        projection: MapProjection,
+        index: int,
+        step: int,
+        target_window:Optional[Window]=None
+    ):
 
         if self.buffer_padding:
             if target_window:
                 target_window = target_window.grow(self.buffer_padding)
-            projection = self.map_projection
             area = area.grow(self.buffer_padding * projection.xstep)
             # The index doesn't need updating because we updated area/window
             step += (2 * self.buffer_padding)
 
-        lhs_data = self.lhs._eval(area, index, step, target_window)
+        lhs_data = self.lhs._eval(area, projection, index, step, target_window)
 
         if self.operator is None:
             return lhs_data
@@ -497,12 +569,12 @@ class LayerOperation(LayerMathMixin):
 
         if self.other is not None:
             assert self.rhs is not None
-            rhs_data = self.rhs._eval(area, index, step, target_window)
-            other_data = self.other._eval(area, index, step, target_window)
+            rhs_data = self.rhs._eval(area, projection, index, step, target_window)
+            other_data = self.other._eval(area, projection, index, step, target_window)
             return operator(lhs_data, rhs_data, other_data, **self.kwargs)
 
         if self.rhs is not None:
-            rhs_data = self.rhs._eval(area, index, step, target_window)
+            rhs_data = self.rhs._eval(area, projection, index, step, target_window)
             return operator(lhs_data, rhs_data, **self.kwargs)
 
         return operator(lhs_data, **self.kwargs)
@@ -514,22 +586,24 @@ class LayerOperation(LayerMathMixin):
         # of the sum are done in different types.
         res = 0.0
         computation_window = self.window
+        projection = self.map_projection
         for yoffset in range(0, computation_window.ysize, self.ystep):
             step=self.ystep
             if yoffset+step > computation_window.ysize:
                 step = computation_window.ysize - yoffset
-            chunk = self._eval(self.area, yoffset, step, computation_window)
+            chunk = self._eval(self._get_operation_area(projection), projection, yoffset, step, computation_window)
             res += backend.sum_op(chunk)
         return res
 
     def min(self):
         res = None
         computation_window = self.window
+        projection = self.map_projection
         for yoffset in range(0, computation_window.ysize, self.ystep):
             step=self.ystep
             if yoffset+step > computation_window.ysize:
                 step = computation_window.ysize - yoffset
-            chunk = self._eval(self.area, yoffset, step, computation_window)
+            chunk = self._eval(self._get_operation_area(projection), projection, yoffset, step, computation_window)
             chunk_min = backend.min_op(chunk)
             if (res is None) or (res > chunk_min):
                 res = chunk_min
@@ -538,11 +612,12 @@ class LayerOperation(LayerMathMixin):
     def max(self):
         res = None
         computation_window = self.window
+        projection = self.map_projection
         for yoffset in range(0, computation_window.ysize, self.ystep):
             step=self.ystep
             if yoffset+step > computation_window.ysize:
                 step = computation_window.ysize - yoffset
-            chunk = self._eval(self.area, yoffset, step, computation_window)
+            chunk = self._eval(self._get_operation_area(projection), projection, yoffset, step, computation_window)
             chunk_max = backend.max_op(chunk)
             if (res is None) or (chunk_max > res):
                 res = chunk_max
@@ -561,14 +636,24 @@ class LayerOperation(LayerMathMixin):
         except AttributeError as exc:
             raise ValueError("Layer must be a raster backed layer") from exc
 
+        projection = self.map_projection
+
         destination_window = destination_layer.window
+        destination_projection = destination_layer.map_projection
+        assert destination_projection is not None
+
+        if projection is None:
+            projection = destination_projection
+        else:
+            if projection != destination_projection:
+                raise ValueError("Destination layer and input layers have different projection/scale")
 
         # If we're calculating purely from a constant layer, then we don't have a window or area
         # so we should use the destination raster details.
         try:
             computation_window = self.window
-            computation_area = self.area
-        except AttributeError:
+            computation_area = self._get_operation_area(projection)
+        except (AttributeError, IndexError):
             computation_window = destination_window
             computation_area = destination_layer.area
 
@@ -584,7 +669,7 @@ class LayerOperation(LayerMathMixin):
             step=self.ystep
             if yoffset+step > computation_window.ysize:
                 step = computation_window.ysize - yoffset
-            chunk = self._eval(computation_area, yoffset, step, computation_window)
+            chunk = self._eval(computation_area, projection, yoffset, step, computation_window)
             if isinstance(chunk, (float, int)):
                 chunk = backend.full((step, destination_window.xsize), chunk)
             band.WriteArray(
@@ -601,7 +686,7 @@ class LayerOperation(LayerMathMixin):
 
     def _parallel_worker(self, index, shared_mem, sem, np_dtype, width, input_queue, output_queue, computation_window):
         arr = np.ndarray((self.ystep, width), dtype=np_dtype, buffer=shared_mem.buf)
-
+        projection = self.map_projection
         try:
             while True:
                 # We acquire the lock so we know we have somewhere to put the
@@ -619,7 +704,7 @@ class LayerOperation(LayerMathMixin):
                     break
                 yoffset, step = task
 
-                result = self._eval(self.area, yoffset, step, computation_window)
+                result = self._eval(self._get_operation_area(projection), projection, yoffset, step, computation_window)
                 backend.eval_op(result)
 
                 arr[:step] = backend.demote_array(result)
@@ -656,7 +741,7 @@ class LayerOperation(LayerMathMixin):
         assert (destination_layer is not None) or and_sum
         try:
             computation_window = self.window
-        except AttributeError:
+        except (AttributeError, IndexError):
             # This is most likely because the calculation is on a constant layer (or combination of only constant
             # layers) and there's no real benefit to parallel saving then, so to keep this code from getting yet
             # more complicated just fall back to the single threaded path
@@ -856,12 +941,12 @@ class LayerOperation(LayerMathMixin):
 
 class ShaderStyleOperation(LayerOperation):
 
-    def _eval(self, area, index, step, target_window=None):
+    def _eval(self, area, projection, index, step, target_window=None):
         if target_window is None:
             target_window = self.window
-        lhs_data = self.lhs._eval(area, index, step, target_window)
+        lhs_data = self.lhs._eval(area, projection, index, step, target_window)
         if self.rhs is not None:
-            rhs_data = self.rhs._eval(area, index, step, target_window)
+            rhs_data = self.rhs._eval(area, projection, index, step, target_window)
         else:
             rhs_data = None
 

--- a/yirgacheffe/window.py
+++ b/yirgacheffe/window.py
@@ -8,6 +8,39 @@ from typing import List, Optional, Tuple
 PixelScale = namedtuple('PixelScale', ['xstep', 'ystep'])
 
 @dataclass
+class MapProjection:
+    """Records the map projection and the size of the pixels in a layer.
+
+    This superceeeds the old PixelScale class, which will be removed in version 2.0.
+
+    Parameters
+    ----------
+    name : str
+        The map projection used.
+    xstep : float
+        The number of units horizontal distance a step of one pixel makes in the map projection.
+    ystep : float
+        The number of units verticle distance a step of one pixel makes in the map projection.
+
+    Attributes
+    ----------
+    name : str
+        The map projection used.
+    xstep : float
+        The number of units horizontal distance a step of one pixel makes in the map projection.
+    ystep : float
+        The number of units verticle distance a step of one pixel makes in the map projection.
+    """
+
+    name : str
+    xstep : float
+    ystep : float
+
+    @property
+    def scale(self) -> PixelScale:
+        return PixelScale(self.xstep, self.ystep)
+
+@dataclass
 class Area:
     """Class to hold a geospatial area of data in the given projection.
 

--- a/yirgacheffe/window.py
+++ b/yirgacheffe/window.py
@@ -36,6 +36,14 @@ class MapProjection:
     xstep : float
     ystep : float
 
+    def __eq__(self, other) -> bool:
+        if other is None:
+            return True
+        # to avoid circular dependancies
+        from .rounding import are_pixel_scales_equal_enough  # pylint: disable=C0415
+        return (self.name == other.name) and \
+            are_pixel_scales_equal_enough([self.scale, other.scale])
+
     @property
     def scale(self) -> PixelScale:
         return PixelScale(self.xstep, self.ystep)


### PR DESCRIPTION
This change allows you to load vector layers without specifying the projection or pixel scale for rasterisation, simplifying things for the declarative use case (i.e., you're not calling `read_array` directly on the layer). Yirgacheffe can infer the projection and scale from other layers or the output layer, and use that instead.