### PR TITLE
Tidying details

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "1.7.0"
+version = "1.7.1"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/tests/test_openers.py
+++ b/tests/test_openers.py
@@ -191,3 +191,25 @@ def test_open_two_raster_areas_side_by_side(tiled):
             with yg.read_raster(path1) as raster1:
                 with yg.read_raster(path2) as raster2:
                     assert group.sum() == raster1.sum() + raster2.sum()
+
+@pytest.mark.parametrize("tiled", [False, True])
+def test_open_two_raster_by_glob(tiled):
+    with tempfile.TemporaryDirectory() as tempdir:
+        temppath = Path(tempdir)
+        path1 = temppath / "test1.tif"
+        area1 = Area(-10, 10, 10, -10)
+        dataset1 = gdal_dataset_of_region(area1, 0.2, filename=path1)
+        dataset1.Close()
+
+        path2 = temppath / "test2.tif"
+        area2 = Area(10, 10, 30, -10)
+        dataset2 = gdal_dataset_of_region(area2, 0.2, filename=path2)
+        dataset2.Close()
+
+        with yg.read_rasters(temppath.glob("*.tif"), tiled=tiled) as group:
+            assert group.area == Area(-10, 10, 30, -10)
+            assert group.window == Window(0, 0, 200, 100)
+
+            with yg.read_raster(path1) as raster1:
+                with yg.read_raster(path2) as raster2:
+                    assert group.sum() == raster1.sum() + raster2.sum()

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -12,7 +12,6 @@ from yirgacheffe.window import Area, MapProjection, PixelScale, Window
 from yirgacheffe.layers import ConstantLayer, GroupLayer, RasterLayer, RescaledRasterLayer, \
     UniformAreaLayer, VectorLayer
 from yirgacheffe import WGS_84_PROJECTION
-from yirgacheffe._backends import backend
 
 
 def test_pickle_raster_layer() -> None:
@@ -97,7 +96,7 @@ def test_pickle_group_layer() -> None:
 
         group = GroupLayer.layer_from_directory(tempdir)
         expected = group.read_array(0, 0, 100, 100)
-        assert backend.sum_op(expected) != 0 # just check there is meaningful data
+        assert expected.sum() != 0 # just check there is meaningful data
 
         p = pickle.dumps(group)
         restore = pickle.loads(p)
@@ -192,4 +191,4 @@ def test_pickle_rescaled_raster_layer() -> None:
         assert restore.window == Window(0, 0, 2000, 2000)
 
         expected = restore.read_array(0, 0, 100, 100)
-        assert backend.sum_op(expected) != 0 # just check there is meaningful data
+        assert expected.sum() != 0 # just check there is meaningful data

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
-from tests.helpers import gdal_dataset_of_region, gdal_multiband_dataset_with_data
+from tests.helpers import gdal_dataset_of_region, gdal_multiband_dataset_with_data, gdal_dataset_with_data
 from yirgacheffe.window import Area, PixelScale, Window
 from yirgacheffe.layers import RasterLayer, InvalidRasterBand
 from yirgacheffe.rounding import round_up_pixels
@@ -260,3 +260,12 @@ def test_multiband_raster() -> None:
         layer = layers[i]
         actual = layer.read_array(0, 0, 4, 2)
         assert (data == actual).all()
+
+def test_read_array_is_numpy():
+    # This test will fail if we use say the MLX backend without casting it back to numpy
+    data = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    dataset = gdal_dataset_with_data((0.0, 0.0), 0.02, data)
+    with RasterLayer(dataset) as layer1:
+        actual = layer1.read_array(0, 0, 4, 2).astype(int)
+        expected = data.astype(int)
+        assert (actual == expected).all

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -19,7 +19,7 @@ def test_basic_vector_layer_no_filter_match() -> None:
             with RasteredVectorLayer.layer_from_file(path, "id_no = 123", PixelScale(1.0, -1.0), "WGS 84") as _layer:
                 pass
 
-def test_basic_dyanamic_vector_layer() -> None:
+def test_basic_dynamic_vector_layer() -> None:
     with tempfile.TemporaryDirectory() as tempdir:
         path = os.path.join(tempdir, "test.gpkg")
         area = Area(-10.0, 10.0, 10.0, 0.0)
@@ -30,6 +30,10 @@ def test_basic_dyanamic_vector_layer() -> None:
             assert layer.geo_transform == (area.left, 1.0, 0.0, area.top, 0.0, -1.0)
             assert layer.window == Window(0, 0, 20, 10)
             assert layer.projection == WGS_84_PROJECTION
+
+            # The astype here is to catch escaping MLX types...
+            res = layer.read_array(0, 0, 20, 20).astype(int)
+            assert res.sum() > 0
 
 def test_rastered_vector_layer() -> None:
     with tempfile.TemporaryDirectory() as tempdir:

--- a/yirgacheffe/_core.py
+++ b/yirgacheffe/_core.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 from .layers.base import YirgacheffeLayer
 from .layers.group import GroupLayer, TiledGroupLayer
@@ -32,7 +32,7 @@ def read_raster(
     return RasterLayer.layer_from_file(filename, band, ignore_nodata)
 
 def read_rasters(
-    filenames : Union[List[Path],List[str]],
+    filenames : Sequence[Union[Path,str]],
     tiled: bool=False
 ) -> GroupLayer:
     """Open a set of raster files (e.g., GeoTIFFs) as a single layer.

--- a/yirgacheffe/layers/base.py
+++ b/yirgacheffe/layers/base.py
@@ -7,6 +7,7 @@ from .. import __version__
 from ..operators import DataType, LayerMathMixin
 from ..rounding import almost_equal, round_up_pixels, round_down_pixels
 from ..window import Area, MapProjection, PixelScale, Window
+from .._backends import backend
 
 class YirgacheffeLayer(LayerMathMixin):
     """The common base class for the different layer types. Most still inherit from RasterLayer as deep down
@@ -310,6 +311,9 @@ class YirgacheffeLayer(LayerMathMixin):
         )
         return self._read_array_with_window(x, y, width, height, target_window)
 
+    def _read_array(self, x: int, y: int, width: int, height: int) -> Any:
+        return self._read_array_with_window(x, y, width, height, self.window)
+
     def read_array(self, x: int, y: int, width: int, height: int) -> Any:
         """Reads data from the layer based on the current reference window.
 
@@ -329,7 +333,8 @@ class YirgacheffeLayer(LayerMathMixin):
         Any
             An array of values from the layer.
         """
-        return self._read_array_with_window(x, y, width, height, self.window)
+        res = self._read_array(x, y, width, height)
+        return backend.demote_array(res)
 
     def latlng_for_pixel(self, x_coord: int, y_coord: int) -> Tuple[float,float]:
         """Get geo coords for pixel. This is relative to the set view window."""

--- a/yirgacheffe/layers/group.py
+++ b/yirgacheffe/layers/group.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import copy
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Sequence, Union
 
 import numpy as np
 from numpy import ma
@@ -39,14 +39,14 @@ class GroupLayer(YirgacheffeLayer):
     @classmethod
     def layer_from_files(
         cls,
-        filenames: Union[List[Path],List[str]],
+        filenames: Sequence[Union[Path,str]],
         name: Optional[str] = None
     ) -> GroupLayer:
         if filenames is None:
             raise ValueError("filenames argument is None")
-        if len(filenames) < 1:
-            raise GroupLayerEmpty("No files found")
         rasters: List[YirgacheffeLayer] = [RasterLayer.layer_from_file(x) for x in filenames]
+        if len(rasters) < 1:
+            raise GroupLayerEmpty("No files found")
         return cls(rasters, name)
 
     def __init__(
@@ -144,7 +144,7 @@ class GroupLayer(YirgacheffeLayer):
         if len(contributing_layers) == 1:
             layer, adjusted_layer_window, intersection = contributing_layers[0]
             if target_window == intersection:
-                data = layer.read_array(
+                data = layer._read_array(
                     intersection.xoff - adjusted_layer_window.xoff,
                     intersection.yoff - adjusted_layer_window.yoff,
                     intersection.xsize,
@@ -156,11 +156,11 @@ class GroupLayer(YirgacheffeLayer):
 
         result = np.zeros((ysize, xsize), dtype=float)
         for layer, adjusted_layer_window, intersection in contributing_layers:
-            data = layer.read_array(
+            data = layer._read_array(
                 intersection.xoff - adjusted_layer_window.xoff,
                 intersection.yoff - adjusted_layer_window.yoff,
                 intersection.xsize,
-                intersection.ysize,
+                intersection.ysize
             )
             result_x_offset = (intersection.xoff - xoffset) - window.xoff
             result_y_offset = (intersection.yoff - yoffset) - window.yoff
@@ -269,7 +269,7 @@ class TiledGroupLayer(GroupLayer):
             intersection = Window.find_intersection_no_throw([target_window, adjusted_layer_window])
             if intersection is None:
                 continue
-            data = layer.read_array(
+            data = layer._read_array(
                 intersection.xoff - adjusted_layer_window.xoff,
                 intersection.yoff - adjusted_layer_window.yoff,
                 intersection.xsize,

--- a/yirgacheffe/layers/vectors.py
+++ b/yirgacheffe/layers/vectors.py
@@ -490,5 +490,9 @@ class VectorLayer(YirgacheffeLayer):
     def _read_array_with_window(self, _x, _y, _width, _height, _window) -> Any:
         assert NotRequired
 
-    def read_array(self, x: int, y: int, width: int, height: int) -> Any:
+    def _read_array(self, x: int, y: int, width: int, height: int) -> Any:
         return self._read_array_for_area(self.area, None, x, y, width, height)
+
+    def read_array(self, x: int, y: int, width: int, height: int) -> Any:
+        res = self._read_array(x, y, width, height)
+        return backend.demote_array(res)


### PR DESCRIPTION
1. Prevent MLX types escaping via read_array
2. Allow read_rasters to take a sequence so you can use Path.glob