### PR TITLE
Add support for reverse operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
-## v1.10.0 (30/10/2025)
+## v1.10.0 (1/11/2025)
+
+### Added
+
+* Support for [reverse operators](https://docs.python.org/3/reference/datamodel.html#object.__radd__), so that now you can write `1 + layer` just as you could write `layer + 1`, rather than having to cast left hand constants to `yg.constant(1) + layer`
+* Implemented [common subexpression elimination](https://en.wikipedia.org/wiki/Common_subexpression_elimination) to improve performance.
 
 ### Changed
 
-* Implemented [common subexpression elimination](https://en.wikipedia.org/wiki/Common_subexpression_elimination) to improve performance.
 * Area and Window @dataclass types are marked as frozen (i.e., are immutable).
 * Test elements for `isin` can now include sets, not just lists and tuples.
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -253,6 +253,25 @@ def test_add_to_float_layer_by_const(c) -> None:
 
     assert (expected == actual).all()
 
+@pytest.mark.parametrize("c", [
+    (float(2.5)),
+    (int(2)),
+    (np.uint16(2)),
+    (np.float32(2.5)),
+])
+def test_add_to_const_by_float_layer(c) -> None:
+    data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = c + layer1
+    comp.save(result)
+
+    expected = c + data1
+    actual = result.read_array(0, 0, 4, 2)
+
+    assert (expected == actual).all()
+
 def test_sub_from_float_layer_by_const() -> None:
     data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
     layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
@@ -262,6 +281,19 @@ def test_sub_from_float_layer_by_const() -> None:
     comp.save(result)
 
     expected = data1 - 0.5
+    actual = result.read_array(0, 0, 4, 2)
+
+    assert (expected == actual).all()
+
+def test_sub_from_const_by_float_layer() -> None:
+    data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = 0.5 - layer1
+    comp.save(result)
+
+    expected = 0.5 - data1
     actual = result.read_array(0, 0, 4, 2)
 
     assert (expected == actual).all()
@@ -279,6 +311,19 @@ def test_mult_float_layer_by_const() -> None:
 
     assert (expected == actual).all()
 
+def test_mult_const_by_float_layer() -> None:
+    data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = 0.25 * layer1
+    comp.save(result)
+
+    expected = 0.25 * data1
+    actual = result.read_array(0, 0, 4, 2)
+
+    assert (expected == actual).all()
+
 def test_div_float_layer_by_const() -> None:
     data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
     layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
@@ -288,6 +333,21 @@ def test_div_float_layer_by_const() -> None:
     comp.save(result)
 
     expected = backend.demote_array(backend.promote(data1) / 2.5)
+    backend.eval_op(expected)
+
+    actual = backend.demote_array(result.read_array(0, 0, 4, 2))
+
+    assert (expected == actual).all()
+
+def test_div_const_by_float_layer() -> None:
+    data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = 2.5 / layer1
+    comp.save(result)
+
+    expected = backend.demote_array(2.5 / backend.promote(data1))
     backend.eval_op(expected)
 
     actual = backend.demote_array(result.read_array(0, 0, 4, 2))
@@ -309,6 +369,21 @@ def test_floordiv_float_layer_by_const() -> None:
 
     assert (expected == actual).all()
 
+def test_floordiv_const_by_float_layer() -> None:
+    data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = 2.5 // layer1
+    comp.save(result)
+
+    expected = backend.demote_array(2.5 // backend.promote(data1))
+    backend.eval_op(expected)
+
+    actual = backend.demote_array(result.read_array(0, 0, 4, 2))
+
+    assert (expected == actual).all()
+
 def test_remainder_float_layer_by_const() -> None:
     data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
     layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
@@ -324,6 +399,21 @@ def test_remainder_float_layer_by_const() -> None:
 
     assert (expected == actual).all()
 
+def test_remainder_const_by_float_layer() -> None:
+    data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = 2.5 % layer1
+    comp.save(result)
+
+    expected = backend.demote_array(2.5 % backend.promote(data1))
+    backend.eval_op(expected)
+
+    actual = backend.demote_array(result.read_array(0, 0, 4, 2))
+
+    assert (expected == actual).all()
+
 def test_power_float_layer_by_const() -> None:
     data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
     layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
@@ -333,6 +423,21 @@ def test_power_float_layer_by_const() -> None:
     comp.save(result)
 
     expected = backend.promote(data1) ** 2.5
+    backend.eval_op(expected)
+
+    actual = result.read_array(0, 0, 4, 2)
+
+    assert (expected == actual).all()
+
+def test_power_const_by_float_layer() -> None:
+    data1 = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    layer1 = RasterLayer(gdal_dataset_with_data((0.0, 0.0), 0.02, data1))
+    result = RasterLayer.empty_raster_layer_like(layer1)
+
+    comp = 2.5 ** layer1
+    comp.save(result)
+
+    expected = 2.5 ** backend.promote(data1)
     backend.eval_op(expected)
 
     actual = result.read_array(0, 0, 4, 2)

--- a/yirgacheffe/_backends/enumeration.py
+++ b/yirgacheffe/_backends/enumeration.py
@@ -42,6 +42,13 @@ class operators(Enum):
     ROUND = 34
     CEIL = 35
     ISNAN = 36
+    RADD = 37
+    RSUB = 38
+    RMUL = 39
+    RTRUEDIV = 40
+    RFLOORDIV = 41
+    RREMAINDER = 42
+    RPOW = 43
 
 class dtype(Enum):
     """Represents the type of data returned by a layer.

--- a/yirgacheffe/_backends/mlx.py
+++ b/yirgacheffe/_backends/mlx.py
@@ -222,4 +222,11 @@ operator_map: dict[op, Callable] = {
     op.ROUND: mx.round,
     op.CEIL: mx.ceil,
     op.ISNAN: mx.isnan,
+    op.RADD: mx.array.__radd__,
+    op.RSUB: mx.array.__rsub__,
+    op.RMUL: mx.array.__rmul__,
+    op.RTRUEDIV: mx.array.__rtruediv__,
+    op.RFLOORDIV: mx.array.__rfloordiv__,
+    op.RREMAINDER: mx.array.__rmod__,
+    op.RPOW: mx.array.__rpow__,
 }

--- a/yirgacheffe/_backends/numpy.py
+++ b/yirgacheffe/_backends/numpy.py
@@ -160,4 +160,15 @@ operator_map: dict[op, Callable] = {
     op.ROUND: np.round,
     op.CEIL: np.ceil,
     op.ISNAN: np.isnan,
+    # Pylint doesn't recognise the reverse operators, despite them
+    # clearly existing on np.ndarray, so we have to disable the checks
+    # pylint: disable=no-member
+    op.RADD: np.ndarray.__radd__,
+    op.RSUB: np.ndarray.__rsub__,
+    op.RMUL: np.ndarray.__rmul__,
+    op.RTRUEDIV: np.ndarray.__rtruediv__,
+    op.RFLOORDIV: np.ndarray.__rfloordiv__,
+    op.RREMAINDER: np.ndarray.__rmod__,
+    op.RPOW: np.ndarray.__rpow__,
+    # pylint: enable=no-member
 }

--- a/yirgacheffe/_operators/__init__.py
+++ b/yirgacheffe/_operators/__init__.py
@@ -77,23 +77,44 @@ class LayerMathMixin:
     def __add__(self, other):
         return LayerOperation(self, op.ADD, other, window_op=WindowOperation.UNION)
 
+    def __radd__(self, other):
+        return LayerOperation(self, op.RADD, other, window_op=WindowOperation.UNION)
+
     def __sub__(self, other):
         return LayerOperation(self, op.SUB, other, window_op=WindowOperation.UNION)
+
+    def __rsub__(self, other):
+        return LayerOperation(self, op.RSUB, other, window_op=WindowOperation.UNION)
 
     def __mul__(self, other):
         return LayerOperation(self, op.MUL, other, window_op=WindowOperation.INTERSECTION)
 
+    def __rmul__(self, other):
+        return LayerOperation(self, op.RMUL, other, window_op=WindowOperation.INTERSECTION)
+
     def __truediv__(self, other):
         return LayerOperation(self, op.TRUEDIV, other, window_op=WindowOperation.INTERSECTION)
+
+    def __rtruediv__(self, other):
+        return LayerOperation(self, op.RTRUEDIV, other, window_op=WindowOperation.INTERSECTION)
 
     def __floordiv__(self, other):
         return LayerOperation(self, op.FLOORDIV, other, window_op=WindowOperation.INTERSECTION)
 
+    def __rfloordiv__(self, other):
+        return LayerOperation(self, op.RFLOORDIV, other, window_op=WindowOperation.INTERSECTION)
+
     def __mod__(self, other):
         return LayerOperation(self, op.REMAINDER, other, window_op=WindowOperation.INTERSECTION)
 
+    def __rmod__(self, other):
+        return LayerOperation(self, op.RREMAINDER, other, window_op=WindowOperation.INTERSECTION)
+
     def __pow__(self, other):
         return LayerOperation(self, op.POW, other, window_op=WindowOperation.UNION)
+
+    def __rpow__(self, other):
+        return LayerOperation(self, op.RPOW, other, window_op=WindowOperation.UNION)
 
     def __eq__(self, other):
         return LayerOperation(self, op.EQ, other, window_op=WindowOperation.INTERSECTION)


### PR DESCRIPTION
This PR adds support for `__radd__` and friends. Before you could write:

```python
calc = layer1 + 42.0
```

But you could not write:

```python
calc = 42.0 + layer1
```

Instead you had to write:

```python
calc = yg.constant(42.0) + layer1
```

With this PR the plain constant on the LHS now works.