### PR TITLE
Fix for vectors wobbling depending on comparison context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v1.11.1 (01/12/2025)
+
+### Fixed
+
+* Fixed a bug whereby the grid to which polygons was rasterized would wobble depending on the context of the reading the array.
+
 ## v1.11.0 (28/11/2025)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "1.11.0"
+version = "1.11.1"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -164,7 +164,10 @@ def gdal_multiband_dataset_with_data(
 
 
 def make_vectors_with_id(
-    identifier: int, areas: set[Area], filename: str | Path
+    identifier: int,
+    areas: set[Area],
+    filename: str | Path,
+    srs_name: str | None = None,
 ) -> None:
     poly = ogr.Geometry(ogr.wkbPolygon)
 
@@ -178,7 +181,10 @@ def make_vectors_with_id(
         poly.AddGeometry(geometry)
 
     srs = ogr.osr.SpatialReference()
-    srs.ImportFromEPSG(4326)
+    if srs_name is None:
+        srs.ImportFromEPSG(4326)
+    else:
+        srs.SetFromUserInput(srs_name)
 
     package = ogr.GetDriverByName("GPKG").CreateDataSource(filename)
     layer = package.CreateLayer("onlylayer", srs, geom_type=ogr.wkbPolygon)

--- a/tests/unit/test_alignment.py
+++ b/tests/unit/test_alignment.py
@@ -134,3 +134,56 @@ def test_nearest_neighbour_vector_alignment_small_step() -> None:
                             val = selected_pixel.read_array(0, 0, 1, 1)[0][0]
                             expected_value = ((y_index * 3) + x_index) + 1
                             assert val == expected_value
+
+
+def test_vector_layer_consistency() -> None:
+    # This test is based on an issue I observed with an AOH where the habitat and elevation
+    # layers were offset enough that if you anchored the vector to a different one it
+    # rendered as either 4 or 2 pixels. This is unfortunate, but okay if you are at least consistent, but
+    # the rasterization of the vector was happening in the space of which layer you were comparing it
+    # with which meant you got different answers on revert to range on elevation and on habitat :/
+
+    projection = yg.MapProjection('ESRI:54009', 1000.0, -1000.0)
+    species_area = yg.Area(1.0, 1999.0, 1999.0, 1.0)
+
+    data = np.array([[1, 2, 3, 4], [5, 4, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]])
+    expected = np.array([[4, 6], [9, 10]])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = Path(tmpdir) / "focus.gpkg"
+        make_vectors_with_id(42, {species_area}, filename, 'ESRI:54009')
+
+        with yg.from_array(data, (-1000.0, 3000.0), projection) as raster1:
+
+            # Unprojected shape first
+            with yg.read_shape(filename) as range_layer:
+                calc = raster1 * range_layer
+                assert calc.window.xsize == 2
+                assert calc.window.ysize == 2
+                result = calc.read_array(0, 0, 2, 2)
+                assert (result == expected).all()
+
+            # Check with a projected shape
+            with yg.read_shape_like(filename, raster1) as range_layer:
+                assert range_layer.sum() == 4
+                calc = raster1 * range_layer
+                assert calc.window.xsize == 2
+                assert calc.window.ysize == 2
+                result = calc.read_array(0, 0, 2, 2)
+                assert (result == expected).all()
+
+        # Where we expect the size of the range_layer to change size as the polygon aligns or doesn't with
+        # the grid of the raster it is matched with. However, if we then multiple that with a large grid of
+        # ones that is zero aligned we shouldn't see it suddenly to back to a 2x2 grid, which was the bug
+        # that made me write this test case.
+        with yg.from_array(np.ones((16, 16)), (-8000.0, 8000.0), projection) as raster0:
+            for offset in range(-500, 500):
+                with yg.from_array(data, (-1000.0 + offset, 3000.0), projection) as raster1:
+                    with yg.read_shape_like(filename, raster1) as range_layer:
+                        calc = raster0 * range_layer
+                        assert range_layer.sum() == calc.sum()
+
+                with yg.from_array(data, (-1000.0, 3000.0 + offset), projection) as raster1:
+                    with yg.read_shape_like(filename, raster1) as range_layer:
+                        calc = raster0 * range_layer
+                        assert range_layer.sum() == calc.sum()


### PR DESCRIPTION
In the 1.11 update we tied most things to a relative grid system, tracking each layer's nearest neighbour when aligning rasters. However, vector layers were not fixed to any specific grid when being rasterised, and so would rasterise relative to the grid of whatever raster they were being compared with, and this gave inconsistent results within the same program for different calculations. 

This change ensures that rasterisation happens on a consistent grid based on the reference layer provided, or if one isn't provided, tired to a 0, 0 pixel offset for that projection.