### PR TITLE
Improve reprojection area estimate accuracy.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,10 +22,10 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/osgeo/gdal:ubuntu-small-3.11.4
+    container: ghcr.io/osgeo/gdal:ubuntu-small-3.12.4
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: publishing
-    container: ghcr.io/osgeo/gdal:ubuntu-small-3.11.4
+    container: ghcr.io/osgeo/gdal:ubuntu-small-3.12.4
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,10 +21,10 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v2.0.1 (02/06/2026)
+
+### Changes
+
+* Moved to using GDAL's wrap to predict reprojected area rather than a hybrid approach.
+
 ## v2.0.0 (16/04/2026)
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,24 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.11.0
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.12.4
 
 RUN apt-get update -qqy && \
 	apt-get install -qy \
 		git \
 		python3-pip \
+		python3-venv \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& rm -rf /var/cache/apt/*
 
 COPY ./ /root/
 WORKDIR /root/
 
-RUN pip config set global.break-system-packages true
-RUN pip install gdal[numpy]==3.11.0
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install gdal[numpy]==3.12.4
 RUN pip install mlx
-RUN pip install -e .[dev]
+RUN pip install -e .[dev,matplotlib]
 
 RUN python3 -m pytest -vv
 RUN mypy yirgacheffe
-RUN python -m pylint yirgacheffe
+RUN python3 -m pylint yirgacheffe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yirgacheffe"
-version = "2.0.0"
+version = "2.0.1"
 description = "Abstraction of gdal datasets for doing basic math operations"
 readme = "README.md"
 authors = [{ name = "Michael Dales", email = "mwd24@cam.ac.uk" }]

--- a/tests/unit/test_area.py
+++ b/tests/unit/test_area.py
@@ -407,8 +407,8 @@ def test_grid_offset(area: Area, expected: tuple[float, float] | None) -> None:
             Area(
                 -1002230.0,
                 1234040.0,
-                1002460.0,
-                -1229810.0,
+                1002230.0,
+                -1229820.0,
                 MapProjection("esri:54009", 10.0, -10.0),
             ),
         ),
@@ -416,12 +416,12 @@ def test_grid_offset(area: Area, expected: tuple[float, float] | None) -> None:
             Area(
                 -1002230.0,
                 1234040.0,
-                1002460.0,
-                -1229810.0,
+                1002230.0,
+                -1229820.0,
                 MapProjection("esri:54009", 10.0, -10.0),
             ),
             Area(-5.0, 4.99, 5.0, -5.01, MapProjection("epsg:4326", 0.1, -0.1)),
-            Area(-10.1, 9.9, 10.1, -9.9, MapProjection("epsg:4326", 0.1, -0.1)),
+            Area(-10.1, 10.0, 10.1, -10.0, MapProjection("epsg:4326", 0.1, -0.1)),
         ),
     ],
 )
@@ -438,8 +438,8 @@ def test_project_like(lhs: Area, rhs: Area, expected: Area) -> None:
             Area(
                 -1002230.0,
                 1234040.0,
-                1002460.0,
-                -1229810.0,
+                1002230.0,
+                -1229820.0,
                 MapProjection("esri:54009", 10.0, -10.0),
             ),
         ),
@@ -447,16 +447,47 @@ def test_project_like(lhs: Area, rhs: Area, expected: Area) -> None:
             Area(
                 -1002230.0,
                 1234040.0,
-                1002460.0,
-                -1229810.0,
+                1002230.0,
+                -1229820.0,
                 MapProjection("esri:54009", 10.0, -10.0),
             ),
             MapProjection("epsg:4326", 0.1, -0.1),
-            Area(-10.1, 9.9, 10.1, -9.9, MapProjection("epsg:4326", 0.1, -0.1)),
+            Area(-10.1, 10.0, 10.1, -10.0, MapProjection("epsg:4326", 0.1, -0.1)),
         ),
     ],
 )
 def test_reproject(lhs: Area, target: MapProjection, expected: Area) -> None:
+    assert lhs.reproject(target) == expected
+
+
+@pytest.mark.parametrize(
+    "lhs,target,expected",
+    [
+        (
+            Area(-10, 10, 10, -10, MapProjection("epsg:4326", 0.02, -0.02)),
+            MapProjection("epsg:4326", 0.01, -0.01),
+            Area(-10, 10, 10, -10, MapProjection("epsg:4326", 0.01, -0.01)),
+        ),
+        (
+            Area(-10, 10, 10, -10, MapProjection("epsg:4326", 0.02, -0.02)),
+            MapProjection("epsg:4326", 0.04, -0.04),
+            Area(-10, 10, 10, -10, MapProjection("epsg:4326", 0.04, -0.04)),
+        ),
+        (
+            Area(-10.005, 10.005, 9.995, -9.995, MapProjection("epsg:4326", 0.02, -0.02)),
+            MapProjection("epsg:4326", 0.01, -0.01),
+            Area(-10.01, 10.01, 9.99, -9.99, MapProjection("epsg:4326", 0.01, -0.01)),
+        ),
+        (
+            Area(-10.005, 10.005, 9.995, -9.995, MapProjection("epsg:4326", 0.02, -0.02)),
+            MapProjection("epsg:4326", 0.04, -0.04),
+            Area(-10.005, 10.005, 9.995, -9.995, MapProjection("epsg:4326", 0.04, -0.04)),
+        ),
+    ]
+)
+def test_reproject_scaling(lhs: Area, target: MapProjection, expected: Area) -> None:
+    # This is reprojection again, but just changing the scale, which is split
+    # out just to make debugging easier :)
     assert lhs.reproject(target) == expected
 
 

--- a/tests/unit/test_area.py
+++ b/tests/unit/test_area.py
@@ -474,14 +474,14 @@ def test_reproject(lhs: Area, target: MapProjection, expected: Area) -> None:
             Area(-10, 10, 10, -10, MapProjection("epsg:4326", 0.04, -0.04)),
         ),
         (
-            Area(-10.005, 10.005, 9.995, -9.995, MapProjection("epsg:4326", 0.02, -0.02)),
+            Area(-10.004, 10.004, 9.996, -9.996, MapProjection("epsg:4326", 0.02, -0.02)),
             MapProjection("epsg:4326", 0.01, -0.01),
-            Area(-10.01, 10.01, 9.99, -9.99, MapProjection("epsg:4326", 0.01, -0.01)),
+            Area(-10.0, 10.0, 10.0, -10.0, MapProjection("epsg:4326", 0.01, -0.01)),
         ),
         (
-            Area(-10.005, 10.005, 9.995, -9.995, MapProjection("epsg:4326", 0.02, -0.02)),
+            Area(-10.004, 10.004, 9.996, -9.996, MapProjection("epsg:4326", 0.02, -0.02)),
             MapProjection("epsg:4326", 0.04, -0.04),
-            Area(-10.005, 10.005, 9.995, -9.995, MapProjection("epsg:4326", 0.04, -0.04)),
+            Area(-10.004, 10.004, 9.996, -9.996, MapProjection("epsg:4326", 0.04, -0.04)),
         ),
     ]
 )
@@ -489,7 +489,6 @@ def test_reproject_scaling(lhs: Area, target: MapProjection, expected: Area) -> 
     # This is reprojection again, but just changing the scale, which is split
     # out just to make debugging easier :)
     assert lhs.reproject(target) == expected
-
 
 @pytest.mark.parametrize(
     "lhs,target",

--- a/tests/unit/test_reprojected.py
+++ b/tests/unit/test_reprojected.py
@@ -38,7 +38,7 @@ def test_simple_scale_up() -> None:
 
 
 def test_scaling_down_unaligned() -> None:
-    area = Area(-10.005, 10.005, 9.995, -9.995)
+    area = Area(-10.004, 10.004, 9.996, -9.996)
     dataset = gdal_dataset_of_region(area, 0.02)
     with RasterLayer(dataset) as raster:
         assert raster.dimensions == (20.0 / 0.02, 20.0 / 0.02)
@@ -47,12 +47,12 @@ def test_scaling_down_unaligned() -> None:
         layer = raster.as_projection(target_projection, ResamplingMethod.Nearest)
 
         assert layer.dimensions == (20 / 0.01, 20 / 0.01)
-        assert layer.area == Area(-10.01, 10.01, 9.99, -9.99, target_projection)
+        assert layer.area == Area(-10.0, 10.0, 10.0, -10.0, target_projection)
         assert layer.projection == target_projection
 
 
 def test_scaling_up_unaligned() -> None:
-    area = Area(-10.005, 10.005, 9.995, -9.995)
+    area = Area(-10.004, 10.004, 9.996, -9.996)
     dataset = gdal_dataset_of_region(area, 0.02)
     with RasterLayer(dataset) as raster:
         assert raster.dimensions == (20.0 / 0.02, 20.0 / 0.02)

--- a/tests/unit/test_reprojected.py
+++ b/tests/unit/test_reprojected.py
@@ -13,7 +13,6 @@ from yirgacheffe._layers import RasterLayer, ResamplingMethod
 from yirgacheffe import Area, MapProjection
 from yirgacheffe._datatypes import Window
 
-
 def test_simple_scale_down() -> None:
     area = Area(-10, 10, 10, -10)
     dataset = gdal_dataset_of_region(area, 0.02)
@@ -36,6 +35,34 @@ def test_simple_scale_up() -> None:
         assert layer.projection == target_projection
         assert layer.area.geo_transform == (-10, 0.04, 0.0, 10, 0.0, -0.04)
         assert layer.dimensions == (500, 500)
+
+
+def test_scaling_down_unaligned() -> None:
+    area = Area(-10.005, 10.005, 9.995, -9.995)
+    dataset = gdal_dataset_of_region(area, 0.02)
+    with RasterLayer(dataset) as raster:
+        assert raster.dimensions == (20.0 / 0.02, 20.0 / 0.02)
+
+        target_projection = MapProjection("epsg:4326", 0.01, -0.01)
+        layer = raster.as_projection(target_projection, ResamplingMethod.Nearest)
+
+        assert layer.dimensions == (20 / 0.01, 20 / 0.01)
+        assert layer.area == Area(-10.01, 10.01, 9.99, -9.99, target_projection)
+        assert layer.projection == target_projection
+
+
+def test_scaling_up_unaligned() -> None:
+    area = Area(-10.005, 10.005, 9.995, -9.995)
+    dataset = gdal_dataset_of_region(area, 0.02)
+    with RasterLayer(dataset) as raster:
+        assert raster.dimensions == (20.0 / 0.02, 20.0 / 0.02)
+
+        target_projection = MapProjection("epsg:4326", 0.04, -0.04)
+        layer = raster.as_projection(target_projection, ResamplingMethod.Nearest)
+
+        assert layer.dimensions == (20 / 0.04, 20 / 0.04)
+        assert layer.area == Area(-10, 10, 10, -10, target_projection)
+        assert layer.projection == target_projection
 
 
 def test_scaling_up_pixels() -> None:

--- a/yirgacheffe/_datatypes/area.py
+++ b/yirgacheffe/_datatypes/area.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 import math
+import uuid
 from dataclasses import dataclass
 
 from osgeo import gdal
 
 from .mapprojection import MapProjection
+from .._utils import VsimemFile
 
 @dataclass(frozen=True)
 class Area:
@@ -334,21 +336,31 @@ class Area:
         </VRTDataset>'''
 
         src_ds = gdal.Open(vrt_xml)
-        vrt_ds = gdal.AutoCreateWarpedVRT(src_ds, None,
-                                          target_projection._gdal_projection,
-                                          gdal.GRA_NearestNeighbour)
-        gt = vrt_ds.GetGeoTransform()
-        min_x = gt[0]
-        max_y = gt[3]
-        max_x = min_x + gt[1] * vrt_ds.RasterXSize
-        min_y = max_y + gt[5] * vrt_ds.RasterYSize
+
+        with VsimemFile(f"{str(uuid.uuid4())}.vrt") as path:
+            gdal.Warp(path, src_ds, options=gdal.WarpOptions(
+                dstSRS=target_projection._gdal_projection,
+                xRes=target_projection.xstep,
+                yRes=target_projection.ystep,
+                resampleAlg=gdal.GRA_NearestNeighbour,
+                targetAlignedPixels=True,
+            ))
+            vrt_ds = gdal.Open(path)
+
+            gt = vrt_ds.GetGeoTransform()
+            assert gt[1] == target_projection.xstep
+            assert gt[5] == target_projection.ystep
+
+            min_x = gt[0]
+            max_y = gt[3]
+            width = gt[1] * vrt_ds.RasterXSize
+            height = gt[5] * vrt_ds.RasterYSize
+
+        max_x = min_x + width
+        min_y = max_y + height
 
         return Area(
-            math.floor(min_x / target_projection.xstep) * target_projection.xstep,
-            math.ceil(max_y / target_projection.ystep) * target_projection.ystep,
-            math.ceil(max_x / target_projection.xstep) * target_projection.xstep,
-            math.floor(min_y / target_projection.ystep) * target_projection.ystep,
-            target_projection,
+            min_x, max_y, max_x, min_y, target_projection
         )
 
     def project_like(self, other: Area) -> Area:

--- a/yirgacheffe/_datatypes/area.py
+++ b/yirgacheffe/_datatypes/area.py
@@ -346,6 +346,8 @@ class Area:
                 targetAlignedPixels=True,
             ))
             vrt_ds = gdal.Open(path)
+            print(vrt_ds.RasterXSize, vrt_ds.RasterYSize)
+            print(vrt_ds.GetGeoTransform())
 
             gt = vrt_ds.GetGeoTransform()
             assert gt[1] == target_projection.xstep

--- a/yirgacheffe/_datatypes/area.py
+++ b/yirgacheffe/_datatypes/area.py
@@ -346,8 +346,6 @@ class Area:
                 targetAlignedPixels=True,
             ))
             vrt_ds = gdal.Open(path)
-            print(vrt_ds.RasterXSize, vrt_ds.RasterYSize)
-            print(vrt_ds.GetGeoTransform())
 
             gt = vrt_ds.GetGeoTransform()
             assert gt[1] == target_projection.xstep

--- a/yirgacheffe/_layers/reprojected.py
+++ b/yirgacheffe/_layers/reprojected.py
@@ -8,19 +8,8 @@ from osgeo import gdal
 from .._datatypes import Area, MapProjection, Window
 from .rasters import YirgacheffeLayer, RasterLayer
 from .._backends.enumeration import dtype as DataType
+from .._utils import VsimemFile
 
-class VsimemFile:
-    def __init__(self, path):
-        self.path = path
-
-    def __enter__(self):
-        return self.path
-
-    def __exit__(self, *args):
-        try:
-            gdal.Unlink(self.path)
-        except RuntimeError:
-            pass
 
 class ResamplingMethod(Enum):
     """Resampling methods used in reprojecting rasters.
@@ -160,11 +149,11 @@ class ReprojectedRasterLayer(YirgacheffeLayer):
         # VSIMEM space, so we use a uuid4 that should be close enough to collision free
         # without relying on things like pids.
         fid = uuid.uuid4()
-        with VsimemFile(f"/vsimem/src_{fid}.tif") as src_data_path:
+        with VsimemFile(f"src_{fid}.tif") as src_data_path:
             windowed = self._src.as_area(expanded_src_read_area)
             windowed.to_geotiff(src_data_path)
 
-            with VsimemFile(f"/vsimem/warped_{fid}.tif") as warped_data_path:
+            with VsimemFile(f"warped_{fid}.tif") as warped_data_path:
                 gdal.Warp(
                     warped_data_path,
                     src_data_path,
@@ -176,7 +165,7 @@ class ReprojectedRasterLayer(YirgacheffeLayer):
                         width=xsize,
                         height=ysize,
                         resampleAlg=self._method.value,
-                        targetAlignedPixels=False,
+                        targetAlignedPixels=True,
                         outputBounds=(read_area.left, read_area.bottom, read_area.right, read_area.top)
                     )
                 )

--- a/yirgacheffe/_utils.py
+++ b/yirgacheffe/_utils.py
@@ -1,0 +1,17 @@
+
+from pathlib import Path
+
+from osgeo import gdal
+
+class VsimemFile:
+    def __init__(self, path):
+        self.path = Path("/vsimem") / path
+
+    def __enter__(self):
+        return self.path
+
+    def __exit__(self, *args):
+        try:
+            gdal.Unlink(self.path)
+        except RuntimeError:
+            pass


### PR DESCRIPTION
Tom Ball flagged that we had some resized rastes grow by a pixel. Reading the code, in the past we estimated the new area of a reprojected raster by asking GDAL what it would be at the current pixel scale and then resizing it. This now uses GDAL to estimate both, which hopefully is more accurate.